### PR TITLE
Add co-op soulslike UE5 implementation guide

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -1,0 +1,15 @@
+# Guides
+
+Long-form implementation guides and tutorials I keep for my own learning.
+
+> **Note:** the guides in this folder are generated with [Claude](https://claude.com/claude-code)
+> (researched, written, and link-checked in Claude Code sessions) and are intended
+> for **learning purposes only**. They are not official documentation for any of the
+> tools or engines they cover — always cross-check against the linked primary sources
+> before relying on a detail, and expect some drift as the underlying software evolves.
+
+## Contents
+
+| Guide | Description |
+|---|---|
+| [coop-soulslike-ue5](coop-soulslike-ue5/) | A 12-chapter, Blueprint-first guide to building a 2–4 player online co-op soulslike in Unreal Engine 5 |

--- a/guides/coop-soulslike-ue5/01-project-setup.md
+++ b/guides/coop-soulslike-ue5/01-project-setup.md
@@ -1,0 +1,220 @@
+# Chapter 1 — Project Setup & Foundations
+
+> **Goal of this chapter:** a clean UE5 project, configured for multiplayer from day one, with a folder structure and naming convention that won't collapse under its own weight in month three.
+
+---
+
+## 1.1 Why decisions in week 1 matter
+
+A co-op game is not "a single-player game plus networking." Replication touches **every** system: movement, damage, animation, AI, pickups, doors, save games. The single most expensive mistake you can make is building systems single-player-first and "adding multiplayer later" — you will end up rewriting almost everything.
+
+**Rule #0 of this entire guide: every feature is built and tested with 2+ clients from the very first day.**
+
+```mermaid
+flowchart LR
+    A[Build feature<br/>single-player] -->|later...| B[Try to add<br/>replication]
+    B --> C[Discover architecture<br/>is wrong]
+    C --> D[Rewrite feature]
+    D -->|weeks lost| A
+
+    E[Build feature<br/>with 2 PIE clients<br/>from day 1] --> F[Feature works<br/>in co-op forever]
+
+    style A fill:#8b1e1e,color:#fff
+    style B fill:#8b1e1e,color:#fff
+    style C fill:#8b1e1e,color:#fff
+    style D fill:#8b1e1e,color:#fff
+    style E fill:#1e6e2e,color:#fff
+    style F fill:#1e6e2e,color:#fff
+```
+
+## 1.2 Engine version & template
+
+1. Install **Unreal Engine 5.4+** (5.3 works; 5.4/5.5 have better Enhanced Input and networked Chaos). Use the Epic Games Launcher → Unreal Engine → Library → `+`.
+2. Create a new project:
+   - Category: **Games → Third Person**
+   - **Blueprint** (as agreed — C++ can be added to the same project later via *Tools → New C++ Class*, it converts the project in place)
+   - Target Platform: Desktop, Quality: Maximum
+   - **Starter Content: OFF** (keeps the project lean; we'll add what we need)
+   - Name it something short without spaces, e.g. `Ashfall` (I'll use this name in paths throughout the guide).
+
+> **Why the Third Person template?** It ships with a `Character` + `SpringArm` + `Camera` setup, Enhanced Input already wired, and — critically — `CharacterMovementComponent`, which has **built-in, battle-tested network prediction**. You get replicated, client-predicted movement for free. Never build a soulslike on a custom Pawn unless you enjoy writing movement netcode.
+
+## 1.3 Project settings checklist
+
+Open **Edit → Project Settings** and set these now:
+
+| Setting | Location | Value | Why |
+|---|---|---|---|
+| Enable Multiplayer PIE | Editor Prefs → Level Editor → Play | Number of Players = **2–3** | You will always test in co-op |
+| Net Mode | Same panel | **Play as Listen Server** | Matches the shipping architecture (Ch. 2) |
+| Run Under One Process | Same panel | ON (dev), OFF (when testing sessions) | One process is faster to iterate |
+| Default GameMode | Project → Maps & Modes | `BP_AshfallGameMode` (create in 1.5) | Central multiplayer authority |
+| Enhanced Input | Project → Input | Already default in 5.1+ | All input in this guide uses it |
+| Support Windowed | Project → Description | ON | Two windows side by side while testing |
+
+## 1.4 Folder structure
+
+Create this under `Content/` immediately. Everything in the guide references these paths.
+
+```
+Content/
+└── Ashfall/
+    ├── Core/                  # GameMode, GameState, PlayerState, PlayerController, GameInstance
+    ├── Characters/
+    │   ├── Player/            # BP_PlayerCharacter, ABP_Player, input assets
+    │   └── Shared/            # Base classes shared by player & enemies
+    ├── Enemies/
+    │   ├── Common/            # BP_EnemyBase, shared AI assets
+    │   ├── Hollow/            # First basic enemy
+    │   └── Boss_Watcher/      # First boss
+    ├── Combat/                # Damage types, hit reactions, weapon data
+    ├── Components/            # AC_Stats, AC_Combat, AC_LockOn, AC_Interaction ...
+    ├── Data/                  # DataTables, DataAssets, Curves, Enums, Structs
+    ├── Items/                 # Weapons, consumables, pickups
+    ├── Maps/
+    │   ├── L_MainMenu
+    │   ├── L_Hub              # Testing gym / hub level
+    │   └── L_Dungeon01
+    ├── UI/                    # Widgets: HUD, menus, health bars
+    └── World/                 # Bonfires, doors, fog gates, triggers
+```
+
+**Naming convention** (used everywhere in this guide):
+
+| Prefix | Asset type | Example |
+|---|---|---|
+| `BP_` | Blueprint class | `BP_PlayerCharacter` |
+| `AC_` | Actor Component | `AC_Stats` |
+| `ABP_` | Animation Blueprint | `ABP_Player` |
+| `AM_` | Animation Montage | `AM_Attack_Light_01` |
+| `BT_` / `BB_` / `BTT_` / `BTS_` | Behavior Tree / Blackboard / BT Task / BT Service | `BT_Hollow` |
+| `WBP_` | Widget Blueprint | `WBP_HUD` |
+| `DT_` / `DA_` | DataTable / DataAsset | `DT_Weapons` |
+| `E_` / `F_` | Enum / Struct | `E_CombatState` |
+| `IA_` / `IMC_` | Input Action / Mapping Context | `IA_Dodge` |
+| `GE_` / `GA_` | (later, GAS) Effect / Ability | `GA_DodgeRoll` |
+
+## 1.5 Core framework classes
+
+Create these Blueprints in `Content/Ashfall/Core/`. Each inherits from the engine class in parentheses. Chapter 2 explains *why* each one exists and where it lives on the network — for now just create them and wire them up.
+
+1. `BP_AshfallGameInstance` (**GameInstance**) — survives level travel; will hold session logic (Ch. 3).
+2. `BP_AshfallGameMode` (**GameModeBase**) — server-only rules: spawning, death, respawn.
+3. `BP_AshfallGameState` (**GameStateBase**) — replicated world state: boss fight active, world flags.
+4. `BP_AshfallPlayerState` (**PlayerState**) — replicated per-player: souls count, character name, deaths.
+5. `BP_AshfallPlayerController` (**PlayerController**) — input & UI owner; one per player.
+6. `BP_PlayerCharacter` — **reparent the template's `BP_ThirdPersonCharacter`** (or duplicate it) into `Characters/Player/` and rename.
+
+Then in **Project Settings → Maps & Modes**:
+
+- Default GameMode: `BP_AshfallGameMode`
+- In `BP_AshfallGameMode` (Class Defaults): set Game State Class, Player State Class, Player Controller Class, and Default Pawn Class to the classes above.
+- **Project Settings → Maps & Modes → Game Instance Class**: `BP_AshfallGameInstance`.
+
+Class relationship overview:
+
+```mermaid
+classDiagram
+    class GameInstance {
+        Exists once per running game process
+        Survives map travel
+        +HostSession()
+        +JoinSession()
+    }
+    class GameMode {
+        SERVER ONLY
+        +HandlePlayerDeath()
+        +RespawnAtBonfire()
+        +ScaleEnemiesForPlayerCount()
+    }
+    class GameState {
+        Replicated to ALL
+        +bBossFightActive
+        +ActiveBossRef
+        +WorldFlags
+    }
+    class PlayerState {
+        Replicated to ALL, one per player
+        +Souls : int
+        +CharacterName
+        +bIsDowned
+    }
+    class PlayerController {
+        One per player, owned by that player
+        Input, HUD, camera
+    }
+    class PlayerCharacter {
+        Replicated pawn, possessed by PC
+        AC_Stats, AC_Combat, AC_LockOn
+    }
+    GameInstance --> GameMode : loads maps that use
+    GameMode --> GameState : maintains
+    GameMode --> PlayerController : spawns per player
+    PlayerController --> PlayerState : owns
+    PlayerController --> PlayerCharacter : possesses
+```
+
+## 1.6 Test levels
+
+1. Duplicate the template map into `Maps/L_Hub`. Delete the floating text. Add:
+   - A large flat area (combat gym)
+   - A few `Target Point` actors named `PlayerStart` replacements — actually use **Player Start** actors, place **4** of them (max party size).
+2. Create an empty level `Maps/L_MainMenu` (Ch. 3 builds the menu there).
+3. **World Settings** of `L_Hub`: confirm GameMode Override is empty (uses project default).
+
+## 1.7 Source control (do not skip)
+
+Binary `.uasset` files do not merge. Ever. Two people (or you-today and you-yesterday) editing the same Blueprint = one of you loses their work.
+
+- Initialize **Git with Git LFS** (`git lfs track "*.uasset" "*.umap"`) or use **Perforce/Diversion** if you can.
+- Commit after every working feature. Your `.gitignore` needs at minimum:
+
+```gitignore
+Binaries/
+DerivedDataCache/
+Intermediate/
+Saved/
+.vscode/
+.idea/
+*.VC.db
+*.opensdf
+*.opendb
+*.sdf
+*.sln
+*.suo
+*.xcodeproj
+*.xcworkspace
+```
+
+- In-editor: **Edit → Editor Preferences → Loading & Saving → Auto Save** — set it to prompt, not silently save, so you don't commit half-finished graphs.
+
+## 1.8 First multiplayer smoke test
+
+1. Editor toolbar → the `⋮` next to Play → **Number of Players: 2**, Net Mode: **Play as Listen Server**.
+2. Press Play. You should get two windows, each with its own third-person character.
+3. Walk one character around — you should see it move in the *other* window.
+
+If both characters move and see each other: congratulations, the engine's replication is doing its job. Everything we build from here on must keep passing this exact test.
+
+```mermaid
+flowchart TD
+    Start([Press Play, 2 players]) --> Q1{Both windows<br/>show 2 characters?}
+    Q1 -- no --> F1[Check: 2+ PlayerStart actors in level?<br/>GameMode default pawn set?]
+    Q1 -- yes --> Q2{Movement visible<br/>across windows?}
+    Q2 -- no --> F2[Check: pawn is a Character subclass?<br/>Replicates = true on the class?]
+    Q2 -- yes --> Done([Foundation OK — go to Chapter 2])
+```
+
+---
+
+## Chapter checklist
+
+- [ ] UE 5.4+ project from Third Person template, Blueprint, no starter content
+- [ ] PIE configured for 2+ players as Listen Server
+- [ ] Folder structure + naming convention in place
+- [ ] All six core framework classes created and assigned in Maps & Modes
+- [ ] `L_Hub` with 4 Player Starts, `L_MainMenu` placeholder
+- [ ] Git + LFS initialized, first commit made
+- [ ] 2-player smoke test passes
+
+**Next:** [Chapter 2 — Multiplayer Foundations: How Replication Actually Works](02-multiplayer-foundations.md)

--- a/guides/coop-soulslike-ue5/02-multiplayer-foundations.md
+++ b/guides/coop-soulslike-ue5/02-multiplayer-foundations.md
@@ -1,0 +1,209 @@
+# Chapter 2 — Multiplayer Foundations: How Replication Actually Works
+
+> **Goal of this chapter:** you understand the server-authoritative model well enough to answer, for any feature you'll ever build: *"where does this code run, and how does everyone else find out about it?"* Nothing in later chapters makes sense without this one.
+
+---
+
+## 2.1 The one architecture that works
+
+Unreal multiplayer is **server-authoritative**. There is exactly one machine that owns the truth (the *server*); everyone else (*clients*) sends requests and renders whatever the server tells them.
+
+For a 2–4 player co-op game the standard choice is a **listen server**: player 1's game *is* the server, and it also renders the game for player 1. Friends join it. No hosting costs, no server binaries, perfect for "summon a friend" soulslike co-op.
+
+```mermaid
+flowchart TB
+    subgraph HOST["Player 1's machine — LISTEN SERVER"]
+        SRV["Server world<br/>(the truth)<br/>GameMode lives here"]
+        LP["Player 1's local<br/>rendering & input"]
+        SRV <--> LP
+    end
+    subgraph C2["Player 2's machine — CLIENT"]
+        W2["Replicated copy<br/>of the world"]
+    end
+    subgraph C3["Player 3's machine — CLIENT"]
+        W3["Replicated copy<br/>of the world"]
+    end
+    SRV -- "replication:<br/>actor & variable state" --> W2
+    SRV -- "replication" --> W3
+    W2 -- "RPCs: 'I want to attack'" --> SRV
+    W3 -- "RPCs" --> SRV
+```
+
+Key mental model: **clients never *do* things; clients *ask* the server to do things, and then watch the results replicate back.** The single exception is `CharacterMovementComponent`, which predicts movement locally and reconciles — that's why we build on `Character` (Ch. 1).
+
+> **Dedicated server?** Same code, different deployment — the server is a headless process nobody plays on. Everything in this guide works on both. Start listen-server; you can revisit in Chapter 12.
+
+## 2.2 Where each framework class lives
+
+This table is worth printing out. "—" means the class does not exist there at all.
+
+| Class | Server | Owning client | Other clients | Use it for |
+|---|---|---|---|---|
+| **GameMode** | ✅ | — | — | Rules, spawning, death handling. *Server-only = safe place for authority logic* |
+| **GameState** | ✅ | ✅ (replica) | ✅ (replica) | World-wide state every player must see |
+| **PlayerState** | ✅ | ✅ (replica) | ✅ (replica) | Per-player state every player must see (souls, name, downed) |
+| **PlayerController** | ✅ | ✅ | — | Input, HUD, things private to one player |
+| **Pawn/Character** | ✅ | ✅ (replica, *autonomous*) | ✅ (replica, *simulated*) | The body in the world |
+| **HUD / Widgets** | — | ✅ | — | UI is always local-only |
+| **GameInstance** | one per *process* | one per process | one per process | Sessions, data that survives map travel. **Never replicated** |
+
+Consequences you will hit constantly:
+
+- You cannot open a menu from the GameMode (clients don't have it). Instead: GameMode → RPC on PlayerController → PlayerController shows widget.
+- You cannot read another player's PlayerController (you don't have it). Put anything others need to see in **PlayerState**.
+- UI never replicates. UI *reads replicated data* and displays it locally.
+
+## 2.3 Net roles: which copy of the actor am I?
+
+Every replicated actor exists once per machine, and each copy knows its role. In Blueprints: **Switch Has Authority** node, or `Get Local Role`.
+
+```mermaid
+flowchart TD
+    A[Actor copy on this machine] --> B{Role?}
+    B -->|Authority| S["This is the SERVER's copy.<br/>Gameplay decisions happen here."]
+    B -->|AutonomousProxy| O["This is MY pawn on MY client.<br/>Input originates here, sent to server."]
+    B -->|SimulatedProxy| P["Someone else's pawn on my client.<br/>Pure puppet — replicated state only."]
+```
+
+A soulslike example: Player 2 presses *Attack*.
+
+```mermaid
+sequenceDiagram
+    participant P2 as Player 2 client<br/>(AutonomousProxy)
+    participant SRV as Server<br/>(Authority)
+    participant P1 as Player 1 & 3 clients<br/>(SimulatedProxy)
+
+    P2->>P2: InputAction Attack triggered
+    P2->>SRV: Server_Attack (RPC, reliable)
+    SRV->>SRV: Validate: stamina ≥ cost? not staggered?
+    SRV->>SRV: Set CombatState = Attacking, drain stamina
+    SRV->>P2: Multicast_PlayAttackMontage
+    SRV->>P1: Multicast_PlayAttackMontage
+    Note over SRV: Damage traces run on SERVER<br/>during the montage's notify window
+    SRV->>P1: Health variable replicates (RepNotify)
+    SRV->>P2: Health variable replicates (RepNotify)
+```
+
+## 2.4 The three tools of replication
+
+### Tool 1 — Replicated variables (state)
+
+Any variable on a replicated actor can be marked **Replicated** or **RepNotify** in the Details panel. Server changes it → engine pushes the new value to all clients (eventually — it's not instant).
+
+- **Replicated**: value just updates silently.
+- **RepNotify**: value updates *and* an `OnRep_VariableName` function fires on clients — use this to react (update a health bar, play a death anim).
+
+> **Golden rule: only the server writes replicated variables.** If a client writes one, only that client sees the change, and the server will stomp it later. This is the #1 beginner bug.
+
+**RepNotify gotcha:** in Blueprints, `OnRep` fires on *clients* when the value arrives, and on the *server* when you use the `Set w/ Notify` node. Put your reaction logic in the OnRep function and it runs everywhere. Subtlety: on clients it fires only when the value actually *changes*; on the server, `Set w/ Notify` calls it every time, changed or not.
+
+### Tool 2 — RPCs (events)
+
+Remote Procedure Calls = custom events with a **Replicates** setting on the event node:
+
+| RPC type | Who calls it | Where it runs | Typical use |
+|---|---|---|---|
+| **Run on Server** | Owning client | Server | "I pressed dodge" — client asks server to act |
+| **Run on Owning Client** | Server | That one client | "Show YOU the boss intro UI", "you got an item" |
+| **Multicast** | Server ONLY | Server + every client | Cosmetic one-shots: play montage, spawn VFX, sound |
+
+Rules that bite people:
+
+1. **Run on Server RPCs only work from the *owning* client.** A client can call Server RPCs on its own PlayerController, its own Pawn, or components thereof. Calling one on an enemy or another player's pawn silently does nothing. (Route it: My Controller → Server RPC → server acts on the enemy.)
+2. **Multicast called from a client runs only locally.** Always: client → Server RPC → server calls Multicast.
+3. **Reliable vs Unreliable:** Reliable = guaranteed delivery, use for gameplay-critical calls (attack, interact). Unreliable = may drop under load, use for pure cosmetics (footstep dust). Never spam reliable RPCs every tick — you'll saturate the connection.
+
+### Tool 3 — Replicated actor spawning
+
+If the **server** spawns an actor whose class has `Replicates = true`, it automatically appears on all clients. If a *client* spawns one, it exists only for that client (fine for purely cosmetic local things; wrong for anything gameplay).
+
+Actor settings that matter (Class Defaults):
+
+- `Replicates` ✅ for anything gameplay-relevant
+- `Replicate Movement` ✅ for physics/moving actors that aren't Characters
+- `Net Update Frequency` — 100 for pawns is default-ish; drop to 5–10 for slow things like doors
+- `Net Dormancy` — set bonfires/doors to *Dorm Awake→Dormant* patterns later for perf (Ch. 12)
+
+## 2.5 The decision flowchart
+
+For *every* feature you build from Chapter 4 onward, run it through this chart:
+
+```mermaid
+flowchart TD
+    Q0([I need X to happen in my game]) --> Q1{Is X pure cosmetics /<br/>UI / camera / input?}
+    Q1 -- yes --> L["Run it locally.<br/>No replication at all.<br/>(widgets, camera shake, lock-on camera)"]
+    Q1 -- no --> Q2{Is X ongoing STATE<br/>others must see<br/>(health, stamina, door open)?}
+    Q2 -- yes --> RV["Replicated variable (RepNotify).<br/>Server writes it.<br/>OnRep updates visuals/UI."]
+    Q2 -- no --> Q3{Is X a one-shot EVENT<br/>others must see<br/>(montage, VFX, sound)?}
+    Q3 -- yes --> MC["Server → Multicast RPC.<br/>If triggered by a client:<br/>Server RPC first."]
+    Q3 -- no --> Q4{Is X a player REQUEST<br/>(attack, interact, use item)?}
+    Q4 -- yes --> SV["Client → Run-on-Server RPC<br/>→ server validates & executes."]
+    Q4 -- no --> Q5{Private info for<br/>ONE player<br/>(loot popup, tutorial)?}
+    Q5 -- yes --> OC["Server → Run-on-Owning-Client RPC,<br/>or non-replicated var on their PC."]
+```
+
+**State vs event, the subtle one:** montages are events, health is state. If a player *joins mid-fight*, they receive current **state** (boss at 40% HP) but never receive **events** that already happened (they won't see an old montage — fine — but they also won't see anything you *only* did via multicast, like a door you "opened" by multicasting an animation. Doors need a replicated `bIsOpen` + OnRep!). Rule: **if late joiners must see it, it's state, not an event.**
+
+## 2.6 Ownership in one minute
+
+Every actor has an **Owner** (a connection, effectively a PlayerController chain). Ownership determines:
+
+- whether your Run-on-Server RPCs go through (see 2.4),
+- who counts as "owning client" for Run-on-Owning-Client RPCs.
+
+Your possessed Character is owned by your PlayerController automatically. A weapon you spawn and attach on the server should get `Set Owner` = the wielding character, so the client who holds it can call Server RPCs through it. When an interaction "belongs to no one" (a bonfire), you don't call Server RPCs *on the bonfire* — you call one on *your own character/controller* and pass the bonfire as a parameter.
+
+## 2.7 Hands-on: prove all of it in 20 minutes
+
+Build this throwaway test in `L_Hub` — it cements everything above.
+
+**A replicated "pressure plate + door":**
+
+1. New Blueprint `BP_TestDoor` (Actor): a cube, `Replicates = ON`.
+   - Variable `bIsOpen` (bool) — **RepNotify**.
+   - In `OnRep_bIsOpen`: set the cube's relative location Z += 300 if open, back if closed. (This is the visual reaction — it runs on server *and* clients.)
+2. New Blueprint `BP_TestPlate` (Actor): box collision, `Replicates = ON`.
+   - `On Component Begin Overlap` →
+
+```text
+Blueprint: BP_TestPlate — Event Graph
+──────────────────────────────────────
+[OnComponentBeginOverlap (Box)]
+ → [Switch Has Authority]
+     (Authority) → [Cast to BP_PlayerCharacter (Other Actor)]
+                    → [Get DoorRef] → [Set bIsOpen (w/ Notify) = true]
+     (Remote)    → (do nothing — overlap also fires on clients; only the
+                    server is allowed to change game state)
+```
+
+3. Place both in the level, wire the plate's `DoorRef` (Instance Editable variable) to the door.
+4. Play with 2 players. Either player steps on the plate → the door rises **in both windows**.
+
+Now break it on purpose (this teaches more than the working version):
+
+- Remove the `Switch Has Authority`, run only the `Remote` path on a client → door opens on one screen only, then never syncs. **Lesson: clients writing state = desync.**
+- Replace the RepNotify variable with a Multicast RPC that plays the move → works live, but stop and use `Open Level` mid-game or imagine a late joiner: no `bIsOpen` state exists → new player sees a closed door while everyone else sees it open. **Lesson: late joiners need state.**
+
+## 2.8 Debugging toolkit (bookmark this)
+
+| Tool | How | What it shows |
+|---|---|---|
+| Network role on screen | `Print String` of `Get Local Role` → `Enum to String` | Which copy is executing |
+| Who am I? | PIE window titles show "Server" / "Client 1" | Never debug without checking which window you're in |
+| `stat net` | console (\`) | Bandwidth, channels, ping |
+| Network Profiler / Insights | `Tools → Session Frontend` / Unreal Insights with `-trace=net` | Deep-dive on bandwidth per actor/property |
+| Simulated lag | Editor Prefs → Play → Additional Launch Params, or console `Net PktLag=120` (see also `p.NetPing`) | Your game MUST be tested with 100–150 ms lag before you ship anything |
+| Two windows, always | PIE Number of Players ≥ 2 | Non-negotiable |
+
+> **Test with lag early.** On localhost PIE everything looks instant and you'll unconsciously build things that feel awful at 120 ms ping. UE lets you simulate latency/packet loss in PIE: Editor Preferences → Level Editor → Play → Multiplayer Options → *Enable Network Emulation* (set Average Latency 100–150 ms). Turn it on at least one test session in three.
+
+---
+
+## Chapter checklist
+
+- [ ] You can state, from memory: which classes exist on server/client, the 3 RPC types and their rules, replicated var vs RepNotify vs multicast
+- [ ] Door/plate test built, working, and *broken on purpose* both ways
+- [ ] You know the decision flowchart in 2.5 (it gets applied in every later chapter)
+- [ ] Network emulation tried at 120 ms
+
+**Next:** [Chapter 3 — Sessions: Hosting, Finding, and Joining Games](03-sessions-and-joining.md)

--- a/guides/coop-soulslike-ue5/03-sessions-and-joining.md
+++ b/guides/coop-soulslike-ue5/03-sessions-and-joining.md
@@ -1,0 +1,161 @@
+# Chapter 3 — Sessions: Hosting, Finding, and Joining Games
+
+> **Goal of this chapter:** a main menu where one player clicks **Host**, friends click **Join**, and everyone ends up in `L_Hub` together — over LAN first, then Steam.
+
+---
+
+## 3.1 How joining works in Unreal
+
+A *session* is an advertised game that others can discover. The flow:
+
+```mermaid
+sequenceDiagram
+    participant H as Host (Player 1)
+    participant OSS as Online Subsystem<br/>(NULL = LAN, Steam, EOS)
+    participant C as Client (Player 2)
+
+    H->>OSS: Create Session (max 4 players)
+    H->>H: Open Level "L_Hub" ?listen
+    Note over H: Host is now a listen server
+    C->>OSS: Find Sessions
+    OSS-->>C: [Session list]
+    C->>OSS: Join Session (result index)
+    C->>H: Client Travel to host's IP
+    Note over H,C: Both players in L_Hub,<br/>GameMode spawns pawn for Player 2
+```
+
+The **Online Subsystem (OSS)** is a swappable backend. Same Blueprint nodes work over:
+
+| Subsystem | Discovery | Use when |
+|---|---|---|
+| **NULL** (default) | LAN broadcast only | Development, same-network testing |
+| **Steam** | Steam friends/servers, NAT punch-through | Shipping on Steam |
+| **EOS** | Epic Online Services, free, crossplay | Shipping outside Steam / crossplay |
+
+Build everything against NULL first. Switching to Steam later is config + minor node changes, not a rewrite.
+
+## 3.2 The session Blueprints (engine-built-in nodes)
+
+Put session logic in `BP_AshfallGameInstance` — it survives map travel, and menus can always reach it (`Get Game Instance → Cast`).
+
+**Host:**
+
+```text
+Blueprint: BP_AshfallGameInstance — function HostGame
+─────────────────────────────────────────────────────
+[Custom Event HostGame]
+ → [Create Session]
+     Player Controller: Get Player Controller(0)
+     Max Public Connections: 4
+     Use LAN: true            ◄ NULL subsystem needs this true
+   (On Success) → [Open Level (by Name)]
+                    Level Name: L_Hub
+                    Options:   "listen"        ◄ THE critical part
+   (On Failure) → [Print String "Create Session failed"]
+```
+
+`?listen` (the `Options: listen`) is what makes the host a **listen server**. Forget it and joiners will connect to nothing.
+
+**Find + Join:**
+
+```text
+Blueprint: BP_AshfallGameInstance — function FindAndJoin
+────────────────────────────────────────────────────────
+[Custom Event FindGames]
+ → [Find Sessions]
+     Max Results: 20
+     Use LAN: true
+   (On Success: Results) → [ForEachLoop] → build a row widget per result
+                            (row shows: server name, ping, 2/4 players)
+   (On Failure) → [Print String "Find failed"]
+
+[Custom Event JoinGame (SessionResult)]
+ → [Join Session (Result)]
+   (On Success) → engine auto-travels this client to the host
+   (On Failure) → [Print String "Join failed"]
+```
+
+> These three nodes (`Create Session`, `Find Sessions`, `Join Session`) live in the **Online** category and come from the *Online Subsystem* + *Online Subsystem Utils* plugins (enabled by default).
+
+## 3.3 Main menu UI
+
+1. `WBP_MainMenu` in `Content/Ashfall/UI/`: three buttons — **Host**, **Join**, **Quit** — and a vertical box `ServerList`.
+2. `L_MainMenu` level: World Settings → GameMode Override → a bare `BP_MenuGameMode` whose Default Pawn = None; a `BP_MenuController` that on BeginPlay creates `WBP_MainMenu`, adds to viewport, and sets **Input Mode UI Only** + `Show Mouse Cursor`.
+3. Buttons call the GameInstance functions from 3.2.
+4. Project Settings → Maps & Modes → **Game Default Map = L_MainMenu**.
+
+Menu flow:
+
+```mermaid
+stateDiagram-v2
+    [*] --> MainMenu : game launch
+    MainMenu --> Hosting : Host clicked
+    Hosting --> InGame_Host : CreateSession OK →<br/>OpenLevel L_Hub?listen
+    MainMenu --> ServerBrowser : Join clicked
+    ServerBrowser --> Joining : row clicked
+    Joining --> InGame_Client : JoinSession OK →<br/>auto ClientTravel
+    InGame_Host --> MainMenu : Leave (Destroy Session → Open L_MainMenu)
+    InGame_Client --> MainMenu : Leave (Destroy Session → Open L_MainMenu)
+```
+
+**Leaving cleanly matters:** always call `Destroy Session` before returning to the menu (host *and* client), or the next `Create Session` will fail with a stale session. Handle it in a `LeaveGame` function on the GameInstance. Also handle `Event NetworkError` / `Event TravelError` in the GameInstance: Destroy Session → Open `L_MainMenu`.
+
+## 3.4 Testing sessions properly
+
+PIE's "Run Under One Process" **bypasses real session discovery**. To truly test host/join:
+
+- Editor Prefs → Play → **Run Under One Process: OFF**, Number of Players: 2, Net Mode: *Play Standalone*. Two real processes start; use your menu to host in one, find+join in the other.
+- Or package a dev build (Ch. 12) and run two copies.
+
+Day-to-day feature work: keep One Process ON and Listen Server mode (skips the menu). Session testing: once per milestone.
+
+## 3.5 Upgrading to Steam
+
+When you want internet play with friends:
+
+1. Enable the **Online Subsystem Steam** plugin (Edit → Plugins).
+2. Add to `Config/DefaultEngine.ini`:
+
+```ini
+[/Script/Engine.GameEngine]
++NetDriverDefinitions=(DefName="GameNetDriver",DriverClassName="OnlineSubsystemSteam.SteamNetDriver",DriverClassNameFallback="OnlineSubsystemUtils.IpNetDriver")
+
+[OnlineSubsystem]
+DefaultPlatformService=Steam
+
+[OnlineSubsystemSteam]
+bEnabled=true
+SteamDevAppId=480          ; 480 = "Spacewar", Valve's public test AppId.
+                           ; Replace with your own AppId when you have one.
+bInitServerOnClient=true   ; needed for listen servers to advertise on Steam
+
+[/Script/OnlineSubsystemSteam.SteamNetDriver]
+NetConnectionClassName="OnlineSubsystemSteam.SteamNetConnection"
+```
+
+3. In your Create/Find Session nodes set **Use LAN: false** for Steam.
+4. Steam must be **running** on both machines; two machines need **two different Steam accounts**. AppId 480 is shared by every dev on Earth, so Find Sessions will also return strangers' test sessions — filter by a custom session setting (see Advanced Sessions below) or just test with Join-via-friends.
+5. Steam does not work in-editor reliably — test Steam with **packaged builds**.
+
+### Advanced Sessions plugin (recommended once on Steam)
+
+The stock session nodes can't set a server name, read player Steam names/avatars, or add custom session filters. The free, long-maintained **Advanced Sessions Plugin** (by mordentral, on the Unreal forums/VRExpansion site) adds Blueprint nodes for all of that (`Create Advanced Session`, `Find Sessions Advanced` with filters, `Get Player Name`, invites). Drop the two plugin folders (`AdvancedSessions`, `AdvancedSteamSessions`) into `Ashfall/Plugins/`, restart, replace your three session nodes with the Advanced variants. Node flow is identical, so this is a 30-minute swap.
+
+> **EOS alternative:** if you'd rather not use Steam, UE ships an EOS OnlineSubsystem — the same session nodes work; configuration goes through Project Settings → Online Services and the EOS Dev Portal. Steam is the smoother path if your audience is on Steam anyway.
+
+## 3.6 Player identity across the session
+
+While you're here, wire up names — you'll want them for the party HUD (Ch. 11):
+
+- `BP_AshfallPlayerState` already replicates `Get Player Name` (Steam name arrives automatically on Steam; on NULL it's "Player").
+- Add a replicated `CharacterClass`/`Loadout` variable to PlayerState later if you add character creation.
+
+## Chapter checklist
+
+- [ ] Host/Join/Quit menu working over LAN with Run-Under-One-Process OFF
+- [ ] `?listen` in the host's Open Level; Destroy Session on leave (both sides)
+- [ ] NetworkError/TravelError handled (return to menu instead of hanging)
+- [ ] (When ready) Steam ini config in place, tested with packaged builds
+- [ ] (Optional) Advanced Sessions plugin swapped in
+
+**Next:** [Chapter 4 — The Player Character: Locomotion, Stamina & Dodge](04-character-locomotion.md)

--- a/guides/coop-soulslike-ue5/04-character-locomotion.md
+++ b/guides/coop-soulslike-ue5/04-character-locomotion.md
@@ -1,0 +1,252 @@
+# Chapter 4 — The Player Character: Locomotion, Stamina & Dodge Roll
+
+> **Goal of this chapter:** a networked character with walk/sprint, a replicated stamina pool, and a dodge roll with i-frames — the physical core of soulslike *feel*. Two clients, everything visible on both screens, always.
+
+---
+
+## 4.1 The component architecture
+
+Resist stuffing everything into `BP_PlayerCharacter`. Split behavior into **Actor Components** — enemies will reuse them, and it keeps each Blueprint graph readable.
+
+```mermaid
+flowchart TB
+    subgraph BP_PlayerCharacter
+        CMC[CharacterMovementComponent<br/><i>engine: predicted movement</i>]
+        MESH[Skeletal Mesh + ABP_Player]
+        CAM[SpringArm + Camera]
+        AC1[AC_Stats<br/>HP / Stamina / Poise<br/>replicated]
+        AC2[AC_Combat<br/>attacks, combos, damage windows<br/>Ch. 6]
+        AC3[AC_LockOn<br/>targeting, camera<br/>Ch. 7]
+        AC4[AC_Interaction<br/>bonfires, pickups<br/>Ch. 10]
+    end
+    ENEMY[BP_EnemyBase<br/>Ch. 8] -. reuses .-> AC1
+    ENEMY -. reuses .-> AC2
+```
+
+Create `AC_Stats` (Blueprint → Actor Component) in `Content/Ashfall/Components/`. **Class Defaults → Component Replicates = ON** (components replicate only if this is set *and* the owning actor replicates).
+
+## 4.2 AC_Stats — stamina first
+
+Variables on `AC_Stats`:
+
+| Variable | Type | Replication | Notes |
+|---|---|---|---|
+| `MaxStamina` | float (100) | Replicated | changed rarely |
+| `Stamina` | float (100) | **RepNotify** | OnRep updates UI |
+| `StaminaRegenRate` | float (25/s) | none | server-only logic |
+| `StaminaRegenDelay` | float (1.2 s) | none | delay after spending |
+| `bStaminaExhausted` | bool | RepNotify | for the "gasping" state (optional) |
+| `OnStaminaChanged` | Event Dispatcher | — | UI binds to this |
+
+**Server-side regen** (all stat mutation happens on the server — Rule from Ch. 2):
+
+```text
+Blueprint: AC_Stats — Event Graph
+─────────────────────────────────
+[Event Tick]                       ◄ fine for a tutorial; see note below
+ → [Switch Has Authority] (Authority only)
+ → [Branch: (Now - LastStaminaSpendTime) > StaminaRegenDelay]
+     True → [Set Stamina (w/ Notify) =
+              Clamp(Stamina + StaminaRegenRate * DeltaSeconds, 0, MaxStamina)]
+
+[Function TrySpendStamina (Cost) → bool]     ◄ SERVER-ONLY helper
+ → [Branch: Stamina >= Cost]
+     True  → [Set Stamina (w/ Notify) = Stamina - Cost]
+            → [Set LastStaminaSpendTime = Game Time in Seconds]
+            → Return true
+     False → Return false
+
+[OnRep_Stamina]
+ → [Call OnStaminaChanged (dispatcher)]      ◄ runs on server + clients;
+                                               UI (local) hears it
+```
+
+> **Bandwidth note:** a float changing every tick replicates every net update. That's acceptable for 4 players. If you ever care, quantize: replicate stamina as a byte 0–100. Don't optimize this now.
+>
+> **RepNotify + Set node:** always change RepNotify variables with the **Set w/ Notify** version of the node on the server, so the OnRep also runs server-side (the listen-server host is a player too — their UI needs the event!).
+
+**Stamina bar:** in `WBP_HUD` (created by `BP_AshfallPlayerController` on BeginPlay, only when `Is Local Player Controller`), bind a ProgressBar to `Stamina / MaxStamina` of the owning pawn's `AC_Stats` via the `OnStaminaChanged` dispatcher (event-driven; avoid property bindings that poll every frame).
+
+## 4.3 Movement states: walk / sprint
+
+Soulslike movement = walk (default), sprint (hold, drains stamina), and later dodge (tap the same key — classic Dark Souls binding).
+
+Enhanced Input assets in `Characters/Player/Input/`:
+
+| Asset | Type | Bound to |
+|---|---|---|
+| `IA_Move` | Axis2D | WASD / left stick (template has this) |
+| `IA_Look` | Axis2D | Mouse / right stick (template has this) |
+| `IA_SprintDodge` | Digital | Left Shift / B (circle) |
+| `IA_Attack` | Digital | LMB / RB — Ch. 6 |
+| `IA_LockOn` | Digital | MMB / R3 — Ch. 7 |
+| `IA_Interact` | Digital | E / A (cross) — Ch. 10 |
+
+**Sprint, networked.** `Max Walk Speed` is *not* replicated by default, and movement is client-predicted — so the correct pattern is to change speed on **both** the owning client (for instant prediction) *and* the server (so the server simulation agrees and other clients see it):
+
+```text
+Blueprint: BP_PlayerCharacter — sprint
+──────────────────────────────────────
+[IA_SprintDodge Triggered(Hold ≥ 0.25s)]        ◄ Hold trigger on the IA
+ → [SetSprinting true (local)] → [Server_SetSprinting true]
+
+[IA_SprintDodge Completed]
+ → [SetSprinting false (local)] → [Server_SetSprinting false]
+
+[Function SetSprinting (bool)]
+ → [Branch] true:  CharacterMovement → Set Max Walk Speed = 600
+            false: CharacterMovement → Set Max Walk Speed = 350
+
+[Custom Event Server_SetSprinting (bool)]   (Run on Server, Reliable)
+ → [SetSprinting]         ◄ server sets it too → replicates pose to others
+ → also: gate it — only allow if Stamina > 0
+```
+
+Sprint stamina drain: on the server (Tick, Authority): if sprinting *and actually moving* (`Velocity length > 10`), `TrySpendStamina(SprintCostPerSecond * Delta)`; on failure, `Server_SetSprinting(false)` and notify the owning client to clear its local flag (Run-on-Owning-Client RPC or a RepNotify `bIsSprinting`).
+
+**Tap vs hold on one key:** give `IA_SprintDodge` two triggers — **Tap** (released < 0.2 s → dodge) and **Hold** (≥ 0.25 s → sprint). Enhanced Input's `Triggered`/`Completed` events + trigger types handle this cleanly without timers.
+
+## 4.4 The dodge roll
+
+The signature move. Requirements: costs stamina, moves you a fixed distance in the input direction, has **i-frames** (a window where you can't be hit), can't be spammed, and looks right on all machines.
+
+### Animation setup
+
+You need a roll animation. Options:
+
+- Free: **Game Animation Sample Project** (Epic, free on Fab) has traversal anims; many free packs on Fab include rolls; Mixamo has rolls you can retarget to the UE5 Mannequin with the IK Retargeter.
+- Create `AM_DodgeRoll` — an **Animation Montage** from the roll animation, in a dedicated `FullBody` montage slot (create the slot in the Skeleton's Anim Slot Manager, and add a `DefaultSlot`→`FullBody` slot node into `ABP_Player`'s AnimGraph after the locomotion state machine).
+
+### Root motion — the decision
+
+A roll animation with baked root motion moves the capsule *exactly* as animated — great feel. But root motion + networking has a long history of jank (simulated proxies extrapolating, desyncs on laggy clients).
+
+| Approach | Feel | Network behavior | Verdict |
+|---|---|---|---|
+| **Root motion montage** (`Root Motion from Montages Only` in ABP) | Exact, designer-tuned | Works via montage replication; simulated proxies can drift slightly on bad connections | ✅ **Use this.** It's the standard for soulslikes; drift at 4 players is negligible |
+| In-place anim + `Launch Character` | Physics-y, floaty | Perfect prediction via CMC | fallback if your anims lack root motion |
+| Root Motion Source / Motion Warping | Best of both | Needs C++/careful setup | later, with C++ |
+
+Set `ABP_Player` → Class Defaults → **Root Motion Mode = Root Motion from Montages Only**.
+
+### The networked dodge flow
+
+```mermaid
+sequenceDiagram
+    participant OC as Owning client
+    participant S as Server
+    participant SP as Other clients
+
+    OC->>OC: IA tap → local checks (montage not playing, predicted stamina > cost)
+    OC->>OC: Play AM_DodgeRoll immediately (prediction: feels instant)
+    OC->>S: Server_Dodge(InputDirection)
+    S->>S: Validate: TrySpendStamina(25)? CombatState == Idle?
+    alt valid
+        S->>S: Play montage on server (moves the authoritative capsule)
+        S->>SP: Multicast_PlayDodge (skip owning client — already playing)
+        S->>S: CombatState = Dodging (RepNotify)
+    else invalid
+        S->>OC: Client_RejectDodge → stop montage, snap back
+    end
+```
+
+```text
+Blueprint: BP_PlayerCharacter — dodge
+─────────────────────────────────────
+[IA_SprintDodge Triggered(Tap)]
+ → [Branch: CombatState == Idle AND Stamina >= DodgeCost]   ◄ local pre-check
+ → [RotateTowardInput]      ◄ set actor rotation to last Move input direction
+                              (soulslike rolls go where you POINT, not where you face)
+ → [Play Anim Montage: AM_DodgeRoll]                        ◄ local prediction
+ → [Server_Dodge (ControlRotation-relative input dir)]
+
+[Custom Event Server_Dodge (Dir)]        (Run on Server, Reliable)
+ → [Branch: CombatState == Idle AND TrySpendStamina(DodgeCost)]
+     True  → [Set Actor Rotation = Dir]
+           → [Play Anim Montage: AM_DodgeRoll]              ◄ authoritative
+           → [Multicast_PlayDodge]
+           → [Set CombatState (w/Notify) = Dodging]
+     False → [Client_RejectDodge]        (Run on Owning Client)
+
+[Custom Event Multicast_PlayDodge]       (Multicast, Unreliable is fine)
+ → [Branch: NOT Is Locally Controlled]   ◄ owner already predicted it
+ → [Play Anim Montage: AM_DodgeRoll]
+
+[On Montage Ended/Blended Out (AM_DodgeRoll)]  (server)
+ → [Set CombatState (w/Notify) = Idle]
+```
+
+> **Simpler alternative you may see in tutorials:** just `Server_Dodge → Multicast_Play` with no local prediction. It works, and at LAN latencies feels fine — but at 100 ms ping your roll starts 100 ms after the button press, which in a soulslike is death. The prediction pattern above is the same amount of Blueprint and feels right; keep it.
+
+### I-frames
+
+I-frames are a *server* concept (the server decides hits, Ch. 5). Implement with an **AnimNotifyState** — a colored band you drag across the timeline of `AM_DodgeRoll`:
+
+1. In `AM_DodgeRoll`, right-click the Notifies track → Add Notify State → **New Blueprint Notify State** → `ANS_Invincible`.
+2. `ANS_Invincible` overrides `Received_NotifyBegin` / `Received_NotifyEnd`:
+
+```text
+Blueprint: ANS_Invincible
+─────────────────────────
+[Received_NotifyBegin (MeshComp, ...)]
+ → [Get Owner of MeshComp] → [Get AC_Stats] → [Set bInvincible = true]
+[Received_NotifyEnd]
+ → ... → [Set bInvincible = false]
+```
+
+3. Place the state band over roughly frames 15–60 % of the roll (tune later!).
+   **Safety net:** `NotifyEnd` is not guaranteed if the montage gets interrupted (e.g. you're hit out of the roll by an unblockable). Also clear `bInvincible` in the character's `On Montage Ended` (Interrupted = true) handler, or you'll ship an immortality bug.
+4. `bInvincible` needs **no replication**: the montage also plays on the server (authoritative copy), so the notify sets the flag on the server's `AC_Stats`, which is where damage is decided. Clients' copies of the flag are irrelevant.
+5. In the damage pipeline (Ch. 5), the server checks `bInvincible` before applying damage.
+
+> Classic tuning: Dark Souls rolls are ~13 i-frames at 30 fps (~0.43 s) mid-roll, with vulnerable startup and recovery. Start there.
+
+## 4.5 The combat state enum (you'll use it everywhere)
+
+Create `E_CombatState` (Enum) in `Data/`: `Idle, Attacking, Dodging, Staggered, Downed, Dead`. On `BP_PlayerCharacter` (or better: `AC_Combat` next chapter), variable `CombatState`, **RepNotify**.
+
+The rule that keeps a melee game sane: **every action first checks the state machine, and transitions are server-authoritative.**
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Attacking : attack accepted (server)
+    Attacking --> Attacking : combo window input (Ch. 6)
+    Attacking --> Idle : montage ends
+    Idle --> Dodging : dodge accepted (server)
+    Dodging --> Idle : montage ends
+    Idle --> Staggered : poise broken (Ch. 5)
+    Attacking --> Staggered : poise broken
+    Staggered --> Idle : stagger anim ends
+    Idle --> Downed : HP 0 in co-op (Ch. 11)
+    Attacking --> Downed : HP 0
+    Dodging --> Downed : HP 0
+    Downed --> Idle : revived (Ch. 11)
+    Downed --> Dead : bleed-out / solo death
+    Dead --> [*] : respawn at bonfire (Ch. 10)
+```
+
+## 4.6 Test matrix (run it now, with 2 clients + 120 ms emulated lag)
+
+| Test | Expected |
+|---|---|
+| Sprint as client 2 | Speed-up visible on both windows; stamina drains on both HUDs |
+| Sprint to zero stamina | Forced back to walk on both windows |
+| Dodge as client 2 | Roll starts instantly on client 2, ~1 RTT later on host window |
+| Dodge with no stamina | No roll (local pre-check), or starts-and-corrects under packet loss |
+| Spam dodge | Only one roll; state machine blocks the rest |
+| Dodge direction | Rolls toward WASD direction, not camera-forward |
+
+---
+
+## Chapter checklist
+
+- [ ] `AC_Stats` with replicated, server-authoritative stamina + regen delay
+- [ ] Event-driven stamina bar on the HUD
+- [ ] Tap/hold on one key: dodge vs sprint via Enhanced Input triggers
+- [ ] Root-motion dodge with client prediction + server validation
+- [ ] `ANS_Invincible` i-frame window in the montage
+- [ ] `E_CombatState` + replicated state machine gating all actions
+- [ ] Full test matrix passes at 120 ms emulated lag
+
+**Next:** [Chapter 5 — Stats & the Damage Pipeline](05-stats-and-damage.md)

--- a/guides/coop-soulslike-ue5/05-stats-and-damage.md
+++ b/guides/coop-soulslike-ue5/05-stats-and-damage.md
@@ -1,0 +1,163 @@
+# Chapter 5 — Stats & the Damage Pipeline
+
+> **Goal of this chapter:** one damage pipeline that every attack in the game — player weapons, enemy claws, boss slams, fall damage — flows through. Health, poise, stagger, hit reactions, and death, all server-authoritative, all visible to every player.
+
+---
+
+## 5.1 Extend AC_Stats
+
+Add to `AC_Stats` (component replicates = ON, from Ch. 4):
+
+| Variable | Type | Replication | Purpose |
+|---|---|---|---|
+| `MaxHealth` | float (100) | Replicated | |
+| `Health` | float | **RepNotify** | OnRep → health bars, death visuals |
+| `MaxPoise` | float (50) | none (server-only) | resistance to stagger |
+| `Poise` | float | none (server-only) | clients never need it |
+| `PoiseRegenRate` | float (10/s) | none | regen like stamina, shorter delay |
+| `bInvincible` | bool | none (server-only) | set by `ANS_Invincible` (Ch. 4) |
+| `bIsDead` | bool | RepNotify | |
+| `OnHealthChanged` | Dispatcher | — | payload: NewHealth, MaxHealth, Delta |
+| `OnDamaged` | Dispatcher | — | payload: Amount, Instigator, HitInfo — fired server-side |
+| `OnPoiseBroken` | Dispatcher | — | server-side |
+| `OnDeath` | Dispatcher | — | payload: Killer — fired server-side, and on clients via OnRep_bIsDead |
+
+**Why poise isn't replicated:** clients never display poise (souls games hide it); only the server's stagger decision matters. Not replicating it is free bandwidth. If you later add a poise bar for bosses, flip it to RepNotify then.
+
+## 5.2 Use the engine's damage plumbing
+
+Unreal ships a damage route: **`Apply Damage`** (or `Apply Point Damage` with hit info) → target's **`Event AnyDamage`** (or `Event PointDamage`). Use it — every actor gets a uniform entry point, you get `Damage Causer`, `Instigated By` (controller), and `Damage Type` for free, and later systems (fall damage, hazards) plug in without new wiring.
+
+Create damage type classes (Blueprint Class → parent `DamageType`) in `Combat/`: `DMG_Physical`, `DMG_Fire`, and give `DMG_Physical` two float defaults you'll read via the class: nothing yet — keep damage numbers on the *weapon* (Ch. 6); damage *types* are for resistances later.
+
+## 5.3 The pipeline
+
+Everything below runs **on the server only** — `Apply Damage` must only ever be called from server-side code (weapon traces in Ch. 6 already run there; `Event AnyDamage` fires where ApplyDamage was called, so keep the calls server-side).
+
+```mermaid
+flowchart TD
+    A["Attacker (server): Apply Point Damage<br/>BaseDamage, HitResult, DamageType"] --> B["Target: Event Point/AnyDamage<br/>in BP_PlayerCharacter / BP_EnemyBase"]
+    B --> C{"AC_Stats:<br/>bInvincible OR bIsDead?"}
+    C -- yes --> X([ignore — i-frames!])
+    C -- no --> D{Blocking? <i>(optional, 5.7)</i>}
+    D -- yes --> E[Reduced dmg + stamina chip<br/>block-impact reaction]
+    D -- no --> F["Health = Clamp(Health - Dmg)  (w/ Notify)"]
+    F --> G["Poise -= attack's PoiseDamage"]
+    G --> H{Poise <= 0?}
+    H -- yes --> I["Poise = MaxPoise<br/>CombatState = Staggered<br/>Multicast_PlayHitReact(Heavy)"]
+    H -- no --> J["Multicast_PlayHitReact(Light)<br/><i>(flinch — or nothing for armored enemies)</i>"]
+    I --> K{Health <= 0?}
+    J --> K
+    K -- yes --> L["HandleDeath (5.6)"]
+    K -- no --> M([done])
+```
+
+```text
+Blueprint: BP_PlayerCharacter / BP_EnemyBase — damage entry
+───────────────────────────────────────────────────────────
+[Event AnyDamage (Damage, DamageType, InstigatedBy, DamageCauser)]
+ → [AC_Stats → ReceiveDamage (Damage, PoiseDamage*, InstigatedBy, DamageCauser)]
+
+    *PoiseDamage: read from the DamageCauser's weapon data (Ch. 6);
+     pass 0 for hazards.
+
+Blueprint: AC_Stats — function ReceiveDamage   (SERVER ONLY — add an
+                                                Authority check at the top)
+──────────────────────────────────────────────
+[Branch: bInvincible OR bIsDead] → true: return
+[Set Health (w/Notify) = Clamp(Health - Damage, 0, MaxHealth)]
+[Set Poise = Poise - PoiseDamage] ; [Set LastPoiseDamageTime]
+[Call OnDamaged]
+[Branch: Poise <= 0]
+   true → [Set Poise = MaxPoise] → [Call OnPoiseBroken]
+[Branch: Health <= 0]
+   true → [Set bIsDead (w/Notify) = true] → [Call OnDeath (InstigatedBy)]
+```
+
+The owning character binds to those dispatchers on BeginPlay (server side): `OnPoiseBroken` → set `CombatState = Staggered`, play stagger montage via multicast; `OnDeath` → `HandleDeath` (5.6).
+
+## 5.4 Hit reactions
+
+One montage per direction is the polish version; start with a single flinch:
+
+> **Directional reacts, when you're ready** (the standard algorithm, straight from the Druid Mechanics course codebase): flatten the impact point to the victim's Z; `ToHit = Normalize(ImpactPoint - ActorLocation)`; `Theta = Acos(Dot(ActorForward, ToHit))` in degrees; if `Cross(Forward, ToHit).Z < 0` negate Theta. Then −45..45 → front, 45..135 → right, −135..−45 → left, else back — and `Montage Jump to Section` into a 4-section hit-react montage. Pass the `HitResult` through your multicast so every machine computes the same section.
+
+- `AM_HitReact_Light` (short flinch, upper-body slot so movement continues) and `AM_HitReact_Heavy` (full-body stagger, root motion knockback if the anim has it).
+- Play via Multicast from the server (these are cosmetic *events*):
+
+```text
+[Custom Event Multicast_PlayHitReact (E_HitReactType)]  (Multicast, Unreliable)
+ → [Select montage by type] → [Play Anim Montage]
+```
+
+- **Hitstop** (the tiny freeze that sells impact): when your hit lands (Ch. 6 sends a `Client_HitConfirmed` to the attacking player), freeze *just the two combatants*: `Set Custom Time Dilation = 0.05` on the attacker and (via their simulated proxy, cosmetically) the victim → `Set Timer by Event (0.08 s)` → restore both to `1.0`. Per-actor dilation beats `Set Global Time Dilation` because global dilation also slows the `Delay` node you'd use to end it (a classic trap) and stutters everyone else's game. Purely local juice — never replicate time dilation. Add camera shake (`Play World Camera Shake`) for both hitter (small) and victim (bigger, via their OnDamaged→local check).
+
+**Damage numbers / blood VFX:** clients can react locally inside `OnRep_Health` (they know the delta) — spawn a floating damage number widget or Niagara blood burst there. Late joiners don't need old VFX, so an event-shaped reaction to a state change is correct here.
+
+## 5.5 Health bars
+
+Three consumers of the same `OnHealthChanged` dispatcher:
+
+| UI | Where it lives | How |
+|---|---|---|
+| My HP bar | `WBP_HUD` (local) | bind to own pawn's dispatcher (rebind on respawn!) |
+| Ally HP bars | `WBP_HUD` party list (Ch. 11) | bind via each ally's PlayerState→Pawn |
+| Enemy overhead bar | `WidgetComponent` on `BP_EnemyBase`, Screen space | the widget binds to its owner's dispatcher; show only after first damage, hide after 5 s no-damage (classic souls lock-on bar comes in Ch. 7) |
+
+Because OnRep fires on every client and `Set w/Notify` fires it on the listen server, **one dispatcher drives all machines' UI with zero extra replication.**
+
+## 5.6 Death (single-player version, upgraded in Ch. 10/11)
+
+Server, on `OnDeath`:
+
+```text
+[HandleDeath (server)]
+ → [Set CombatState (w/Notify) = Dead]
+ → [Multicast_OnDeath]
+ → [Disable capsule collision (Pawn channel ignore)] ; [Stop movement]
+ → [GameMode → NotifyPlayerDied(Controller)]   ◄ GameMode decides respawn (Ch.10)
+
+[Multicast_OnDeath]
+ → [Play AM_Death montage]  (or enable ragdoll: Set Simulate Physics on mesh)
+ → [If locally controlled: show "YOU DIED" widget, disable input]
+```
+
+Enemies: same pipeline, but `HandleDeath` also awards souls to the killer's PlayerState (Ch. 10) and tells the AI to stop (Ch. 8).
+
+## 5.7 Optional now, recommended later: blocking
+
+Hold-to-block fits the same pipeline: `bIsBlocking` (RepNotify, server-set via Server RPC like sprint), and in `ReceiveDamage`, if blocking *and* the attacker is within the front 120° arc (`Dot(Forward, DirToAttacker) > -0.5` — actually use `Dot > 0.5` of victim-forward vs *direction to attacker*): damage ×0.1, stamina −= chip cost, play block-impact instead of hit react; if stamina hits 0 → guard break = forced `Staggered`. Slot it in at the `Blocking?` diamond in the 5.3 flowchart.
+
+## 5.8 Test with a training dummy
+
+Make `BP_TrainingDummy` (parent: Character, or an Actor with a mesh + `AC_Stats`), place two in `L_Hub`, and give yourself a debug attack before Chapter 6 exists:
+
+```text
+[IA_Attack Triggered]  → [Server_DebugAttack]
+[Server_DebugAttack]   (Run on Server)
+ → [Sphere Trace For Objects (Pawn), start=actor loc, end=loc+forward*150, r=60]
+ → [Apply Point Damage: 25 dmg, 30 poise (pass via interface or cast), DMG_Physical]
+```
+
+Test matrix (2 clients + lag emulation):
+
+| Test | Expected |
+|---|---|
+| Client 2 hits dummy | HP bar drops on **both** screens simultaneously |
+| Hit during ally's roll i-frames | zero damage (server honored `bInvincible`) |
+| 2 fast hits | poise breaks on the configured threshold, heavy react plays everywhere |
+| Kill the dummy | death montage/ragdoll on both screens; corpse doesn't block movement |
+| Attacker hitstop | freeze frame only on the attacker's window |
+
+---
+
+## Chapter checklist
+
+- [ ] Health/poise added to `AC_Stats`; all mutation server-side
+- [ ] Single `ReceiveDamage` pipeline; i-frames and death respected inside it
+- [ ] `Apply [Point] Damage` / `Event AnyDamage` used as the transport
+- [ ] Light/heavy hit reacts multicast; hitstop + shake local-only
+- [ ] HP bars all event-driven off one dispatcher
+- [ ] Dummy test matrix passes
+
+**Next:** [Chapter 6 — Melee Combat: Weapons, Combos & Hit Detection](06-melee-combat.md)

--- a/guides/coop-soulslike-ue5/06-melee-combat.md
+++ b/guides/coop-soulslike-ue5/06-melee-combat.md
@@ -1,0 +1,214 @@
+# Chapter 6 — Melee Combat: Weapons, Combos & Hit Detection
+
+> **Goal of this chapter:** a light-attack combo chain with weapon-trace hit detection driven by animation notifies, feeding the Chapter 5 damage pipeline — fully networked. This is the heart of the game; budget real time for tuning.
+
+---
+
+## 6.1 Weapon architecture
+
+Weapons are actors (they'll be pickups, they have their own data), attached to the character's hand socket.
+
+1. Skeleton: open the player Skeletal Mesh → Skeleton → add socket on `hand_r` named `WeaponSocket`; rotate/offset until a sword mesh sits right (use *Preview Asset* on the socket).
+2. `BP_WeaponBase` (Actor) in `Items/`: Static Mesh, `Replicates = ON`. Add two **Scene Components** on the blade: `TraceStart` (guard) and `TraceEnd` (tip) — our trace sockets.
+3. Weapon stats in a struct `F_WeaponData` (in `Data/`): `Damage`, `PoiseDamage`, `StaminaCost`, `AttackMontages (array of Anim Montage)`, plus later: scaling, damage type.
+
+   > *Alternative style you'll see in tutorials:* one montage with named **sections** (`Attack01/02/03`, auto-chain links removed in the Montage Sections panel) driven by `Montage Jump to Section`. Functionally equivalent; the array-of-montages version is easier to replicate (you multicast an index either way) and easier to mix weapons, so this guide uses arrays. Store rows in `DT_Weapons` (DataTable) and give `BP_WeaponBase` a `WeaponID (Name)` that looks up its row — designers tune numbers in a spreadsheet-like table instead of hunting through Blueprints.
+4. Spawning (server!): in `BP_PlayerCharacter` BeginPlay:
+
+```text
+[Event BeginPlay] → [Switch Has Authority] (Authority)
+ → [Spawn Actor BP_WeaponBase (WeaponID = StarterSword)]
+ → [Attach to Component: Mesh, Socket = WeaponSocket, Snap to Target]
+ → [Set Owner = self]          ◄ ownership: lets us route RPCs later
+ → [Set CurrentWeapon = it]    ◄ CurrentWeapon: Replicated var
+```
+
+Because the weapon replicates and attachment replicates, clients see it appear in the hand automatically.
+
+## 6.2 AC_Combat and the combo state
+
+Create `AC_Combat` (Actor Component, **Component Replicates = ON**) — move `CombatState` (from Ch. 4) here. Add:
+
+| Variable | Type | Replication | Purpose |
+|---|---|---|---|
+| `CombatState` | E_CombatState | RepNotify | the master gate |
+| `ComboIndex` | int | none (server) | which attack in the chain |
+| `bComboWindowOpen` | bool | none (server) | set by notify |
+| `bComboQueued` | bool | none (server) | input buffering |
+| `HitActorsThisSwing` | Set of Actor | none (server) | prevent multi-hit per swing |
+
+## 6.3 The combo system
+
+Soulslike combos = pressing attack during a window near the end of swing N chains into swing N+1. Plus **input buffering**: pressing slightly *early* still counts. Without buffering, combat feels unresponsive — this detail matters more than any damage number.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Attack1 : attack input (server validated,<br/>stamina spent)
+    Attack1 --> Attack2 : input during/queued into<br/>combo window
+    Attack2 --> Attack3 : same
+    Attack3 --> Idle : chain ends
+    Attack1 --> Idle : window missed → montage blends out
+    Attack2 --> Idle : window missed
+    note right of Attack1
+        Each attack = one section or montage:
+        AM_Attack_Light_01/02/03
+        Startup → Active(trace) → Recovery(combo window)
+    end note
+```
+
+```text
+Blueprint: BP_PlayerCharacter — attack input
+────────────────────────────────────────────
+[IA_Attack Triggered]
+ → [Branch: locally-predicted OK? (state Idle-or-Attacking, stamina > 0)]
+ → [Server_Attack]
+
+Blueprint: AC_Combat — server side
+──────────────────────────────────
+[Custom Event Server_Attack]   (Run on Server, Reliable)
+ → [Branch: CombatState == Idle]
+     True  → [StartAttack(0)]
+     False → [Branch: CombatState == Attacking AND bComboWindowOpen]
+                True  → [StartAttack(ComboIndex + 1)]
+                False → [Branch: CombatState == Attacking]   ◄ input buffer:
+                          True → [Set bComboQueued = true]     early press
+                                                               remembered
+[Function StartAttack (Index)]        (SERVER)
+ → [Branch: Index < len(Weapon.AttackMontages)] false → return
+ → [Branch: Stats.TrySpendStamina(Weapon.StaminaCost)] false → return
+ → [Set CombatState (w/Notify) = Attacking]
+ → [Set ComboIndex = Index] ; [Set bComboWindowOpen/bComboQueued = false]
+ → [Clear HitActorsThisSwing]
+ → [Play Anim Montage: AttackMontages[Index]]     ◄ server copy: authoritative
+                                                    (traces run off this one)
+ → [Multicast_PlayAttack (Index)]
+
+[Custom Event Multicast_PlayAttack (Index)]   (Multicast, Reliable)
+ → [Branch: NOT Is Locally Controlled OR NOT predicted]  → [Play Anim Montage]
+    (simplest robust version: skip prediction for attacks entirely and play
+     for everyone here, including the attacker — see the latency note below)
+
+[On Montage Ended / Blended Out]   (server, bind when playing)
+ → [Branch: CombatState == Attacking] → [Set CombatState (w/Notify) = Idle]
+```
+
+> **Prediction for attacks?** In Chapter 4 we predicted the dodge locally. For attacks, start *without* prediction (client presses → server plays → multicast). At listen-server-with-friends latencies (~30–80 ms) attack startup hides the delay, because soulslike attacks have long windups by design. If it feels muddy for the joining client later, add the same predict-and-reconcile pattern as the dodge. Keep the combo/window logic server-only either way.
+
+### Combo window + buffered input, via Anim Notifies
+
+In each `AM_Attack_Light_XX` montage add plain **AnimNotifies** (not states): `AN_ComboWindowBegin` near the end of the active swing and `AN_ComboWindowEnd` before the montage ends. New Blueprint notifies, each calls into the owner:
+
+```text
+[AN_ComboWindowBegin → Received_Notify]
+ → [Owner.AC_Combat] → [Branch: Has Authority]      ◄ notifies fire on every
+                                                      machine playing the
+                                                      montage; act on server
+ → [Set bComboWindowOpen = true]
+ → [Branch: bComboQueued] true → [StartAttack(ComboIndex+1)]  ◄ buffer pays out
+
+[AN_ComboWindowEnd → Received_Notify]
+ → (authority) [Set bComboWindowOpen = false]
+```
+
+## 6.4 Hit detection: socket-to-socket weapon traces
+
+The standard soulslike approach: during the damage window of the swing, sweep the blade's volume each frame and damage what it passes through. Collision-overlap hitboxes are frame-rate dependent and miss fast swings; traces between *last frame's* and *this frame's* socket positions don't tunnel.
+
+```mermaid
+flowchart LR
+    subgraph Montage timeline
+        direction LR
+        SU[Startup<br/>0.0–0.3s] --> ACT["ANS_WeaponTrace<br/>(damage window)<br/>0.3–0.5s"] --> REC["Recovery + combo window<br/>0.5–0.9s"]
+    end
+    ACT -->|every NotifyTick| T["Sphere Trace Multi<br/>prev tip→current tip<br/>(+ mid-blade point)"]
+    T --> H{hit actor not in<br/>HitActorsThisSwing?}
+    H -- yes --> D["Add to set →<br/>Apply Point Damage<br/>(Ch. 5 pipeline)"]
+```
+
+Create `ANS_WeaponTrace` (AnimNotifyState) and drag it across the active frames of every attack montage:
+
+```text
+Blueprint: ANS_WeaponTrace
+──────────────────────────
+[Received_NotifyBegin]
+ → [Owner = MeshComp.GetOwner] → [Branch: Owner Has Authority] ◄ SERVER ONLY —
+                                                                 damage is
+                                                                 authoritative
+ → [Weapon = Owner.AC_Combat.CurrentWeapon]
+ → [Store PrevStart = Weapon.TraceStart.WorldLocation,
+          PrevEnd   = Weapon.TraceEnd.WorldLocation]
+
+[Received_NotifyTick]
+ → (authority only, as above)
+ → [CurStart/CurEnd = socket world locations now]
+ → For sample points P in {Start, Mid, End}:            ◄ 3 points along blade
+    [Sphere Trace Multi For Objects]
+       Start: PrevP   End: CurP   Radius: 15
+       Object Types: Pawn   Ignore: Owner
+    → [ForEach Hit] → [Branch: Hit.Actor NOT in HitActorsThisSwing]
+        → [Add to HitActorsThisSwing]
+        → [Branch: Hit.Actor is on another team?]   ◄ 6.6, no friendly fire
+        → [Apply Point Damage]
+             Damaged Actor: Hit.Actor
+             Base Damage:   Weapon.Damage
+             Hit Info:      Hit
+             Instigated By: Owner.GetController
+             Damage Causer: Weapon
+             DamageType:    DMG_Physical
+        → [Owner.Client_HitConfirmed]     ◄ Run-on-Owning-Client RPC →
+                                            hitstop + shake (Ch. 5.4)
+ → [PrevStart/PrevEnd = CurStart/CurEnd]
+
+[Received_NotifyEnd] → clear stored positions
+```
+
+Why this works in multiplayer with zero extra code: the montage plays on the **server** (6.3), so the notify state ticks on the server, so traces and `Apply Point Damage` run with authority, so Chapter 5's pipeline replicates the results. The same notify ticking on clients exits early at the authority branch.
+
+> **Free plugin alternative:** the open-source **MeleeTrace** plugin (github.com/rlewicki/MeleeTrace) implements exactly this (multi-socket interpolated traces) with a few Blueprint nodes, if you'd rather not maintain your own. Building it from source needs a C++ project; fine to adopt when you add C++ later. Your hand-rolled version above is ~30 nodes and teaches you the guts.
+
+**Debug it:** Sphere Trace nodes have `Draw Debug Type = For Duration` — turn it on and watch red/green capsules paint the swing arc. Tune the ANS band until the trace covers exactly the frames where the blade visually sweeps.
+
+## 6.5 Heavy attacks, charged attacks
+
+Once lights work, heavies are data + input plumbing, not new systems:
+
+- `IA_Attack` with a **Hold** trigger (or a separate `IA_HeavyAttack` on RMB/RT).
+- `F_WeaponData` gets `HeavyMontages`, `HeavyDamage`, `HeavyPoiseDamage` (poise damage is what makes heavies matter — they stagger through poise, Ch. 5).
+- `Server_Attack` takes an `E_AttackType` param and indexes the right montage array.
+- Hyper armor on heavies: an `ANS_HyperArmor` notify state that sets a server-side `bHyperArmor` flag checked in `ReceiveDamage`'s poise branch (take the damage, skip the stagger).
+
+## 6.6 Teams / no friendly fire
+
+Simplest robust scheme: add a `TeamID (int)` to `AC_Stats` (0 = players, 1 = enemies). In `ANS_WeaponTrace` (and every damage source), compare attacker vs victim `TeamID` before applying damage. Souls games ignore ally-hits in co-op — copy that; friendly fire in a melee game with 4 players in a corridor is misery.
+
+## 6.7 Enemy attacks use the same machinery
+
+`BP_EnemyBase` (Ch. 8) gets `AC_Combat` + weapon (or `TraceStart`/`TraceEnd` sockets on its own limbs for claws/bites) and the same `ANS_WeaponTrace` in its attack montages. One combat system, every attacker. This is the payoff of the component architecture.
+
+## 6.8 Test matrix (2 clients, 120 ms emulation, training dummies)
+
+| Test | Expected |
+|---|---|
+| Single light attack (client 2) | montage on both screens; dummy HP drops on both; hitstop only on client 2 |
+| Mash attack ×3 | full 3-hit chain, no skipped/doubled swings, stamina −3× |
+| Press attack once during swing | buffered — next swing comes out exactly at the window |
+| Attack with 0 stamina | nothing (or whiff-then-correct under loss) |
+| Swing through 2 dummies | both damaged once each; neither hit twice |
+| Ally in the arc | no damage (TeamID) |
+| Attack + get poise-broken mid-swing | montage interrupted by stagger everywhere; `HitActorsThisSwing`/window flags reset; can act after stagger |
+
+That last row is where combat systems rot: **every** flag set during an attack must be cleaned up in `On Montage Ended (Interrupted)`. Audit `bComboWindowOpen`, `bComboQueued`, i-frames, hyper armor.
+
+---
+
+## Chapter checklist
+
+- [ ] Weapon actor with data-table stats, server-spawned, socket-attached
+- [ ] 3-hit combo with server-side windows + input buffering
+- [ ] `ANS_WeaponTrace` socket-sweep hit detection, server-only, no double-hits
+- [ ] Heavy attack + hyper armor
+- [ ] TeamID gate (no friendly fire)
+- [ ] Interrupt-cleanup audit done; full test matrix passes
+
+**Next:** [Chapter 7 — Lock-On Targeting](07-lock-on.md)

--- a/guides/coop-soulslike-ue5/07-lock-on.md
+++ b/guides/coop-soulslike-ue5/07-lock-on.md
@@ -1,0 +1,133 @@
+# Chapter 7 — Lock-On Targeting
+
+> **Goal of this chapter:** classic souls lock-on: press a button, camera hard-locks to the nearest valid enemy, movement becomes strafing, flick the stick/mouse to switch targets, auto-release on death or distance. Almost everything here is **client-local** — a rare networking break.
+
+---
+
+## 7.1 Why lock-on is (mostly) not replicated
+
+The camera never replicates (Ch. 2 table: UI/camera are local). Lock-on is a *camera and input* behavior. The only part of lock-on that other players see is your character's **rotation** — and rotation already replicates through normal movement replication.
+
+```mermaid
+flowchart LR
+    subgraph LOCAL["Client-local, never replicated"]
+        A[Find/validate target] --> B[Rotate CAMERA<br/>toward target each tick]
+        B --> C[Lock-on reticle widget]
+    end
+    subgraph REP["Replicates for free"]
+        D[Character rotation<br/>follows controller yaw] --> E[Other players see<br/>you strafe-facing the enemy]
+    end
+    B --> D
+```
+
+So: no RPCs in this chapter. Build it all in `AC_LockOn` (Actor Component on the player, **no** replication), and only run its logic when `Is Locally Controlled`.
+
+## 7.2 Finding a target
+
+```text
+Blueprint: AC_LockOn — function FindTarget → Actor
+──────────────────────────────────────────────────
+[Sphere Overlap Actors]
+   Sphere Pos:    owner location
+   Sphere Radius: 1500 (LockOnRange)
+   Object Types:  Pawn
+   Class Filter:  BP_EnemyBase (or better: actors implementing BPI_Targetable)
+ → [ForEach] filter candidates:
+     ├─ [Branch: candidate.AC_Stats.bIsDead == false]
+     ├─ [Line Trace By Channel (Visibility): camera loc → candidate chest]
+     │    hit something else first? → skip (no lock through walls)
+     ├─ [Compute angle from camera forward:
+     │     Dot(CameraForward, Normalize(CandidateLoc - CameraLoc))]
+     │    < cos(35°)? → skip (only things roughly on screen)
+     └─ [Score = Angle*Weight + Distance*Weight]   ◄ souls games prefer
+                                                     screen-center over closest
+ → return best-scoring candidate
+```
+
+Two implementation notes:
+
+- **`BPI_Targetable` interface** (Blueprint Interface in `Data/`): functions `CanBeTargeted() → bool` and `GetLockOnLocation() → vector` (a socket on the enemy's chest/head — big bosses need a specific bone, or even multiple targetable points; an interface makes that swappable per enemy without casts).
+- The line-of-sight trace uses the **camera** as origin, not the character — lock-on is about what *you can see*.
+
+## 7.3 Engaging, holding, releasing
+
+State on `AC_LockOn`: `CurrentTarget (Actor)`, local only.
+
+```text
+[IA_LockOn Triggered]
+ → [Branch: CurrentTarget valid?]
+     No  → [FindTarget] → valid? → [EngageLockOn(target)]
+     Yes → [ReleaseLockOn]                       ◄ toggle behavior
+
+[Function EngageLockOn (Target)]
+ → [Set CurrentTarget]
+ → CharacterMovement → [Set Orient Rotation to Movement = false]
+ → Character         → [Set Use Controller Rotation Yaw = true]
+ → [Show WBP_LockOnReticle]   ◄ WidgetComponent on the enemy, or a HUD widget
+                                projected via "Project World to Screen"
+
+[Function ReleaseLockOn]
+ → [Clear CurrentTarget] ; restore both rotation flags ; hide reticle
+
+[Event Tick]  (only when CurrentTarget valid AND Is Locally Controlled)
+ ├─ Auto-release checks:
+ │    [Branch: target dead OR Distance > 2000 OR LOS lost for > 1.5s]
+ │      true → [ReleaseLockOn] (souls behavior: try FindTarget once first —
+ │              retarget to next enemy when your target dies mid-swarm)
+ ├─ Camera:
+ │    [LookAt = Find Look at Rotation (camera loc → target.GetLockOnLocation)]
+ │    [New = RInterp To (Get Control Rotation, LookAt, DeltaTime, Speed=8)]
+ │    [Set Control Rotation (clamp pitch ~ -35..+15, keep roll 0)]
+ └─ (Use Controller Rotation Yaw makes the character face the target,
+     which replicates to everyone — free co-op correctness)
+```
+
+**Movement while locked:** with `Orient Rotation to Movement` off and controller-yaw on, WASD now strafes around the target automatically. For animation, your `ABP_Player` locomotion needs a **strafe blendspace** (forward/right speed in a 2D blendspace) selected when locked — pass `bIsLockedOn` from the character into the AnimBP via `Property Access`/Event Graph. If your anim set lacks strafes, it looks skate-y but plays fine; add a strafe pack from Fab later.
+
+> `bIsLockedOn` for the AnimBP is needed on **all** machines (others see you strafe). Cheapest: make it a Replicated bool set via a Server RPC on engage/release — the one tiny replicated piece in this system. (Rotation itself still replicates regardless.)
+
+## 7.4 Switching targets
+
+Flick the right stick / move the mouse sideways past a threshold while locked:
+
+```text
+[IA_Look (while CurrentTarget valid)]
+ → [Branch: |X| > SwitchThreshold (e.g. 3.0) AND cooldown elapsed (0.4s)]
+ → [FindTarget variant: candidates scored by signed screen-space X offset
+     relative to current target; pick nearest candidate on the flick side]
+ → [EngageLockOn(new target)] ; start cooldown
+```
+
+Implementation trick for "which side": `Project World to Screen` each candidate and the current target; compare screen X. Screen space matches player intuition better than world angles.
+
+## 7.5 Lock-on health bar
+
+Souls-style: the locked enemy shows a boss-style bottom bar or an overhead bar only while targeted.
+
+- On `EngageLockOn`: create/show `WBP_TargetInfo` (name + HP bar), bind to the target's `AC_Stats.OnHealthChanged` dispatcher (Ch. 5 — fires on every machine, so your local UI updates even though damage happens on the server).
+- On `ReleaseLockOn`: unbind + hide. Don't forget unbind — dangling widget bindings to dead actors are a classic crash.
+
+## 7.6 Test matrix
+
+| Test | Expected |
+|---|---|
+| Lock with 3 dummies at angles | picks the most screen-centered one |
+| Enemy behind a wall | never targeted |
+| Flick right | switches to next enemy on the right, 0.4 s cooldown respected |
+| Kill locked target mid-combo | auto-retargets to next enemy (or releases if none) |
+| Walk 25 m away | auto-release |
+| Other window (co-op) | your character visibly strafe-faces the target; no reticle on their screen |
+| Both players lock the same enemy | works — targets are not exclusive |
+
+---
+
+## Chapter checklist
+
+- [ ] `AC_LockOn` fully client-local, `BPI_Targetable` interface on enemies
+- [ ] Screen-center-weighted target scoring, wall + death + range validation
+- [ ] Camera RInterp with pitch clamp; strafe movement while locked
+- [ ] Flick-to-switch in screen space with cooldown
+- [ ] Replicated `bIsLockedOn` for strafe anims on other clients
+- [ ] Target HP widget binds/unbinds cleanly
+
+**Next:** [Chapter 8 — Enemy AI: Behavior Trees & Group Combat](08-enemy-ai.md)

--- a/guides/coop-soulslike-ue5/08-enemy-ai.md
+++ b/guides/coop-soulslike-ue5/08-enemy-ai.md
@@ -1,0 +1,191 @@
+# Chapter 8 — Enemy AI: Behavior Trees & Group Combat
+
+> **Goal of this chapter:** a basic "Hollow" enemy that patrols, spots a player, closes distance, and attacks using the Chapter 6 combat machinery — plus the *attack token* system that makes fighting groups feel like Dark Souls instead of a mosh pit. In co-op, AI also has to *pick which player* to fight.
+
+---
+
+## 8.1 AI runs on the server. Full stop.
+
+`AIController`, Behavior Trees, Blackboards, EQS, and AI Perception exist **only on the server**. Clients just see the enemy pawn's replicated movement and multicast montages. This is great news: AI is the one system where you can mostly forget networking — as long as you remember that any AI-driven *action* must go through the already-networked systems (montages via multicast, damage via the Ch. 5 pipeline).
+
+```mermaid
+flowchart LR
+    subgraph SERVER only
+        P[AIPerception] --> BB[Blackboard]
+        BB --> BT[Behavior Tree]
+        BT --> ACT["Tasks: MoveTo, Attack"]
+    end
+    ACT --> M["AC_Combat.StartAttack<br/>(already multicasts montage)"]
+    ACT --> MV[CharacterMovement]
+    MV -- movement replication --> C[Clients see enemy move]
+    M -- multicast --> C2[Clients see enemy attack]
+```
+
+## 8.2 The enemy pawn
+
+`BP_EnemyBase` (Character) in `Enemies/Common/`:
+
+- `Replicates = ON` (Characters default to this), `AC_Stats` (TeamID = 1), `AC_Combat`, implements `BPI_Targetable` (Ch. 7).
+- Class Defaults → **AI Controller Class** = `AIC_EnemyBase` (create below); **Auto Possess AI = Placed in World or Spawned**.
+- A `PatrolRoute` (array of Target Points, Instance Editable) or just wander-radius.
+- Child it: `BP_Hollow` with mesh, anims, weapon.
+- The level needs a **Nav Mesh Bounds Volume** covering walkable areas (press `P` to visualize the green navmesh).
+
+`AIC_EnemyBase` (AIController):
+
+- Add **AIPerception** component → Senses Config → **AI Sight**: Sight Radius 1500, Lose Sight Radius 2000, Peripheral Vision Half Angle 70°, Detection by Affiliation: tick all three (proper team affiliation needs C++; we filter manually).
+- `Event On Possess` → `Run Behavior Tree (BT_EnemyBase)`.
+
+## 8.3 Blackboard & the state enum
+
+`BB_EnemyBase` keys:
+
+| Key | Type | Meaning |
+|---|---|---|
+| `AIState` | Enum `E_AIState` (Passive, Investigating, Chasing, Attacking, Dead) | master switch |
+| `TargetActor` | Object (Actor) | current victim (a *player* — co-op!) |
+| `PointOfInterest` | Vector | last seen location / patrol point |
+| `AttackRadius` | Float (180) | melee range |
+
+Perception wiring in `AIC_EnemyBase`:
+
+```text
+[AIPerception → On Target Perception Updated (Actor, Stimulus)]
+ → [Branch: Actor implements BPI_Targetable? / is BP_PlayerCharacter? and not dead]
+ → [Break AIStimulus]
+     Successfully Sensed = true:
+        → [SetValueAsObject TargetActor = Actor]
+        → [SetValueAsEnum  AIState = Chasing]
+     Successfully Sensed = false (lost sight):
+        → [SetValueAsVector PointOfInterest = Stimulus.StimulusLocation]
+        → [SetValueAsEnum  AIState = Investigating]
+        → [Set Timer 8s → if still Investigating: clear target, AIState = Passive]
+```
+
+## 8.4 The behavior tree
+
+```mermaid
+flowchart TD
+    ROOT((Root)) --> SEL{Selector}
+    SEL --> D1["[Decorator: AIState == Dead]<br/>(observer aborts: lower priority)<br/>Task: do nothing"]
+    SEL --> A["[AIState == Attacking]<br/>Sequence"]
+    SEL --> CH["[AIState == Chasing]<br/>Sequence"]
+    SEL --> INV["[AIState == Investigating]<br/>Sequence"]
+    SEL --> PAT["[AIState == Passive]<br/>Sequence: patrol"]
+
+    A --> A1[Rotate to face TargetActor]
+    A1 --> A2["BTT_PerformAttack<br/>(request token → AC_Combat.StartAttack →<br/>wait montage end → return token)"]
+    A2 --> A3["Wait 0.8–1.6s<br/>(recovery, randomized)"]
+
+    CH --> C1["BTS service (0.5s): if distance < AttackRadius<br/>AND token available → AIState = Attacking"]
+    C1 --> C2["Move To TargetActor<br/>(acceptance radius ≈ AttackRadius − 40)"]
+
+    INV --> I1[Move To PointOfInterest]
+    I1 --> I2[Wait 3s]
+    I2 --> I3[Set AIState = Passive]
+
+    PAT --> P1["BTT_FindPatrolPoint<br/>(next route point or<br/>Get Random Reachable Point in Radius)"]
+    P1 --> P2["Move To PointOfInterest (walk speed)"]
+    P2 --> P3[Wait 2–5s]
+```
+
+Key mechanics of the tree:
+
+- **Decorators**: each branch is gated by a `Blackboard` decorator on `AIState`, with **Observer Aborts = Lower Priority** — when perception flips the enum, the running branch is interrupted immediately.
+- **Custom tasks** are Blueprints of `BTTask_BlueprintBase`: implement `Event Receive Execute AI` (gives you Owner Controller + Controlled Pawn) and *always* call `Finish Execute` (this is the #1 "my tree is stuck" bug). Handle `Event Receive Abort AI` → `Finish Abort` and clean up (return tokens! see 8.5).
+- **Attack speed** comes from your montages; **chase speed** vs **patrol speed**: set `Max Walk Speed` in tasks/services (server-side is enough for AI — it drives the authoritative movement).
+- `BTT_PerformAttack` calls the same `AC_Combat.StartAttack` players use — enemies automatically get trace-based damage, poise, multicast montages, TeamID filtering. Nothing new to network.
+
+## 8.5 Attack tokens: the soulslike crowd-control secret
+
+If five enemies aggro and all attack at once, melee is unplayable. Souls games (and DOOM, and Assassin's Creed) limit *simultaneous attackers* with a token pool: an enemy may only attack while holding a token; everyone else circles and menaces.
+
+**The pool lives on the victim** — that's what makes it scale to co-op automatically: each *player* has their own pool, so 4 enemies can split across 2 players (2 tokens each) instead of queueing on one global pool.
+
+`AC_AttackTokens` (Actor Component on `BP_PlayerCharacter`, server-only logic, no replication needed):
+
+```text
+Variables: MaxTokens (int, default 2), TokensAvailable (int, init to Max)
+
+[Function RequestToken → bool]     (SERVER — called by AI, AI is server-side)
+ → [Branch: TokensAvailable > 0]
+     true  → [TokensAvailable -= 1] → return true
+     false → return false
+
+[Function ReturnToken]
+ → [TokensAvailable = Min(TokensAvailable + 1, MaxTokens)]
+```
+
+Enemy side, inside `BTT_PerformAttack`:
+
+```text
+[Receive Execute AI]
+ → [Target = BB.TargetActor → AC_AttackTokens.RequestToken]
+     false → [Finish Execute (Success = false)]   ◄ selector falls through to
+                                                    strafe/pressure behavior
+     true  → [Set HeldTokenFrom = Target]
+           → [AC_Combat.StartAttack] → [Bind On Montage Ended]
+[On Montage Ended]  → [ReturnToken] → [Clear HeldTokenFrom] → [Finish Execute (true)]
+[Receive Abort AI]  → [Branch: HeldTokenFrom valid] → [ReturnToken] → [Finish Abort]
+[Enemy death (AC_Stats.OnDeath)] → same token cleanup
+```
+
+> **Token leaks are the classic bug:** any path where an attack is interrupted (stagger, death, target died) must return the token, or your enemies gradually go passive and the game feels "broken but not crashing". If you see enemies circling forever, audit token returns first. Difficulty knob for free: bosses/harder areas raise `MaxTokens` to 3; a passive-heavy area lowers it to 1.
+
+**"Pressure" behavior when no token:** add a branch after `Chasing` in the selector: if in range but `RequestToken` failed → strafe around the target. Simple version: `Move To` a point offset 90° around the player at attack radius (recompute every 2 s). Fancy version: an **EQS** query (`Points: Donut` generator around TargetActor, tests: Distance band + Trace line-of-sight + prefer flanking Dot) — EQS is worth learning once basic AI works.
+
+## 8.6 Picking a target in co-op: simple threat
+
+With 2–4 players, "nearest player" AI gets exploited (one player kites while others wail). Add a threat table — 20 nodes, big payoff:
+
+```text
+AC_Stats.OnDamaged (already exists, Ch. 5)   (server)
+ → enemy's AIC: [ThreatMap (Map: Actor → float)] [Add Damage * 1.0]
+Healing/taunts later: add threat to healer, taunt = huge threat spike.
+
+BTS_SelectTarget (Service on the Selector root, every 1.0s):
+ → [Highest = argmax(ThreatMap, decayed 5%/s)]
+ → [Branch: Highest != current BB.TargetActor AND
+            Highest.Threat > current.Threat * 1.3]   ◄ 30% hysteresis:
+     → [SetValueAsObject TargetActor = Highest]        no rapid flip-flop
+ → [Branch: current target dead/downed] → retarget immediately
+```
+
+Enemies now naturally spread across the party, switch to the player who's actually fighting them, and drop aggro on downed players (who they should ignore — Ch. 11).
+
+## 8.7 Enemy death, cleanup, and respawn hooks
+
+On `AC_Stats.OnDeath` (server), in `BP_EnemyBase`:
+
+1. BB `AIState = Dead`; `Stop Movement`; unpossess or stop the BT (`Stop Logic`).
+2. Return any held token; clear this enemy from all players' threat maps.
+3. Award souls: `GameMode.AwardSouls(KillerController, SoulValue)` → PlayerState (Ch. 10).
+4. Multicast death montage / ragdoll; after 10 s, `Destroy Actor` (corpse cleanup) — or keep corpses until bonfire rest (Ch. 10 spawner pattern handles respawning).
+
+**Spawner pattern (build it now, Ch. 10 depends on it):** never place `BP_Hollow` directly in levels. Place `BP_EnemySpawner` (an Actor storing `EnemyClass`, spawn transform, patrol route). On BeginPlay (server) it spawns its enemy. On bonfire rest: every spawner destroys its live enemy (if any) and respawns fresh. Defeated bosses set a flag the spawner checks.
+
+## 8.8 Test matrix (2 players)
+
+| Test | Expected |
+|---|---|
+| Walk past patrol at distance | no aggro outside sight cone |
+| Enter sight cone | chase → attack when close, visible identically on both windows |
+| 4 enemies vs 1 player | max 2 attack simultaneously, others strafe |
+| 4 enemies vs 2 players | enemies split; each player faces ≤2 attackers |
+| P1 kites, P2 deals damage | enemy switches target to P2 (threat) |
+| Kill enemy mid-attack-windup | token returned; other enemies keep attacking normally |
+| Break line of sight | enemy investigates last seen spot, gives up after ~8 s |
+
+---
+
+## Chapter checklist
+
+- [ ] `BP_EnemyBase` + `AIC_EnemyBase` + BT/BB with state-enum branches & observer aborts
+- [ ] Perception → blackboard wiring with lost-sight investigation
+- [ ] Enemy attacks reuse `AC_Combat` (traces, poise, multicast — free)
+- [ ] Attack tokens on the *player*, leak-proof returns audited
+- [ ] Threat-based target selection with hysteresis
+- [ ] Spawner pattern in place; death awards souls hook stubbed
+- [ ] Full test matrix passes with 2 players
+
+**Next:** [Chapter 9 — The Boss Fight](09-boss.md)

--- a/guides/coop-soulslike-ue5/09-boss.md
+++ b/guides/coop-soulslike-ue5/09-boss.md
@@ -1,0 +1,165 @@
+# Chapter 9 — The Boss Fight
+
+> **Goal of this chapter:** a two-phase boss behind a fog gate, with telegraphed attacks, a phase transition at 50% HP, a bottom-of-screen boss health bar on every player's HUD, and co-op-aware behavior. Bosses are 90% reuse of Chapters 5–8 — the new work is *choreography and state*.
+
+---
+
+## 9.1 What's actually new in a boss
+
+| Boss feature | Built on | New work |
+|---|---|---|
+| Big HP, multiple attacks | `AC_Stats`, `AC_Combat`, BT | data + montages |
+| Phases | BT + Blackboard enum | health-threshold trigger |
+| Boss HP bar for all players | `GameState` + dispatchers | replicated encounter state |
+| Fog gate / arena | Ch. 2 door pattern | encounter manager |
+| Telegraphs | AnimMontages + AnimNotify | Niagara decals, timing |
+| Co-op awareness | threat (8.6), tokens | target-swap rules, HP scaling (Ch. 11) |
+
+## 9.2 Encounter state lives in GameState
+
+Every player needs to see the boss bar, hear the music change, and see the fog gate — including someone who joins mid-fight. Ch. 2 rule: *late joiners need state, not events* → the encounter is **replicated state on `BP_AshfallGameState`**:
+
+| Variable | Type | Replication |
+|---|---|---|
+| `ActiveBoss` | Actor ref | RepNotify → all HUDs show/hide the boss bar |
+| `BossFightState` | Enum (None, Intro, Active, Defeated) | RepNotify → music, fog gate visuals |
+
+```mermaid
+sequenceDiagram
+    participant P as Any player
+    participant S as Server
+    participant GS as GameState (replicated)
+    participant ALL as Every client's HUD
+
+    P->>S: crosses BP_FogGate trigger (server-side overlap)
+    S->>S: BP_BossEncounter.StartFight()
+    S->>GS: ActiveBoss = Watcher, BossFightState = Intro
+    GS-->>ALL: OnRep → boss bar appears, fog gate solidifies, music
+    S->>S: Boss BT enabled after intro montage (multicast)
+    Note over S: fight happens (Ch. 5–8 systems)
+    S->>GS: boss dies → BossFightState = Defeated
+    GS-->>ALL: OnRep → bar fades, "GREAT ENEMY FELLED", gate opens
+```
+
+`BP_BossEncounter` (Actor placed in the level, server logic only): references the fog gates, the boss spawner, and the trigger volume. It's the choreographer:
+
+```text
+[Trigger overlap]  (authority) → [Branch: State == None]
+ → [Close fog gates (replicated bool on the gate actors, Ch. 2 door pattern)]
+ → [Spawn / activate boss]
+ → [GameState: set ActiveBoss + BossFightState = Intro (w/ Notify)]
+ → [Multicast_PlayIntro] → on finish (server timer = intro length):
+ → [BossFightState = Active] → [Boss AIC: Run Behavior Tree]
+
+[Boss AC_Stats.OnDeath]  (server)
+ → [BossFightState = Defeated] ; [Open gates] ; [Set bDefeated flag on spawner]
+ → [GameMode.AwardSouls to EVERY player controller]   ◄ co-op: everyone paid
+```
+
+**Co-op detail — the fog gate:** in souls games, players *outside* the gate when the fight starts can walk through it (one-way membrane) to join, and dead players spectate. Simplest version: the gate blocks only the Pawn channel *from inside*; easiest robust version: gate is solid, but players overlapping the gate get a "Traverse the fog" interact prompt (Ch. 10 interaction) that teleports them in — server-side, no edge cases.
+
+## 9.3 The boss Blueprint
+
+`BP_Boss_Watcher` child of `BP_EnemyBase` — everything inherits. Differences:
+
+- `AC_Stats`: MaxHealth 2500, MaxPoise 300 (bosses barely flinch — but a poise *break* is your "posture broken, big punish" moment), heavy hitstop feel via bigger `PoiseDamage` on its own attacks.
+- **Attack data table** `DT_WatcherAttacks`: rows = `Montage, Damage, PoiseDamage, MinRange, MaxRange, Cooldown, Phase, Weight`. The BT task picks a row instead of hardcoding montages — adding attacks becomes data entry.
+- Implements `GetLockOnLocation` with a chest socket (Ch. 7); huge bosses may expose several lock points.
+- **Doesn't use attack tokens** (a boss is always allowed to attack) but **does use threat** (8.6) with an extra co-op rule below.
+
+## 9.4 The boss behavior tree
+
+`BT_Boss_Watcher`, structured by phase:
+
+```mermaid
+flowchart TD
+    ROOT((Root Selector)) --> DEAD["[State == Dead] idle"]
+    ROOT --> P2["[BossPhase == Phase2] Phase 2 Selector"]
+    ROOT --> P1["[BossPhase == Phase1] Phase 1 Selector"]
+
+    P1 --> P1A["Sequence: in range?<br/>BTT_PickAttack (DT rows, Phase1)<br/>→ perform → recover 1.5–2.5s"]
+    P1 --> P1B["Sequence: out of range<br/>→ gap closer (leap attack row)<br/>or Move To target"]
+
+    P2 --> P2A["Service: every 20s consider<br/>AOE burst if ≥2 players in 400u"]
+    P2A --> P2B["Sequence: BTT_PickAttack (Phase1+Phase2 rows,<br/>faster recovery 0.8–1.5s)"]
+```
+
+`BTT_PickAttack` (server):
+
+```text
+[Receive Execute AI]
+ → [Rows = DT_WatcherAttacks filtered by: Phase ≤ current, MinRange ≤ dist ≤ MaxRange,
+    cooldown elapsed (keep a Map<RowName, LastUsedTime> on the AIC)]
+ → [Weighted random pick]        ◄ weights stop it spamming one move;
+                                   cooldowns force variety
+ → [AC_Combat.StartAttack(row)] → wait montage end → [Finish Execute]
+```
+
+### Phase transition
+
+In `BP_Boss_Watcher`, bound to its own `AC_Stats.OnHealthChanged` (server):
+
+```text
+[Branch: Health/MaxHealth <= 0.5 AND BossPhase == Phase1]
+ → [Set BossPhase = Phase2 on Blackboard (SetValueAsEnum)]  ◄ observer aborts
+                                                              interrupt Phase1 branch
+ → [BT pauses via a bTransitioning BB bool decorator]
+ → [Multicast_PlayMontage(AM_Watcher_PhaseRoar)]  + arena VFX
+ → [Server timer (roar length) → clear bTransitioning]
+ → optional: refill poise, new weapon glow (RepNotify bool → material swap in OnRep)
+```
+
+## 9.5 Telegraphs — the difference between hard and unfair
+
+Souls bosses are readable: every attack has a **windup pose**, often a ground decal for AOEs. Concretely:
+
+- Author montages with 0.4–0.9 s of distinct windup before `ANS_WeaponTrace` opens. Slower = more punishable = fairer for melee.
+- AOE attacks: an `AN_Telegraph` AnimNotify at windup start → since montages play on all machines (multicast), the notify fires client-side too → spawn the warning decal/Niagara **locally** on each client (cosmetic, no replication needed). Damage still only happens on the server when the trace window opens.
+- Give attacks *recovery* you can punish. The attack data table's `Cooldown`+recovery `Wait` is your difficulty dial.
+
+**Camera at giant scale:** lock-on to a huge boss pointing the camera up is the classic pain. Mitigations: lower the lock-on pitch clamp for boss targets, lengthen the spring arm while locked onto anything flagged `bIsLargeTarget`, and consider soft-lock (camera bias, not hard track) for the largest bosses.
+
+## 9.6 Co-op boss rules
+
+- **Target swapping:** pure threat makes a boss tunnel one player. Add to the boss's `BTS_SelectTarget`: after 15–25 s on the same target, or after a big damage spike from another player, force a swap. Both players should get "turns" tanking.
+- **Off-target punishes:** phase 2 AOE (9.4) and at least one attack that targets the *second*-highest threat player keep non-tanking players honest.
+- **Downed players** (Ch. 11): remove them from the threat map; boss ignores bodies (souls-accurate and prevents corpse-camping).
+- **HP scaling:** done globally in Ch. 11 — bosses just inherit it. For reference, Elden Ring scales boss HP roughly ×1.6 with one extra player and ×2.3 with two.
+
+## 9.7 Boss health bar
+
+`WBP_BossBar` in the HUD (bottom, name + big bar):
+
+```text
+WBP_HUD:
+[GameState.OnRep_ActiveBoss → dispatcher → HUD]
+ → valid?   → [Show WBP_BossBar] → [Bind to ActiveBoss.AC_Stats.OnHealthChanged]
+ → invalid? → [Unbind] → [Collapse]
+```
+
+Add a delayed "white damage chip" second bar later (pure UI polish: lerp a second progress bar toward the real value after 0.8 s).
+
+## 9.8 Test matrix (the important ones)
+
+| Test | Expected |
+|---|---|
+| P1 triggers gate while P2 outside | gate closes, P2 can traverse-in via prompt; boss bar on both HUDs |
+| Join a session mid-fight *(test with One-Process OFF)* | late joiner sees boss bar, correct HP, closed gate |
+| Burst boss 55%→45% | exactly one roar, phase 2 attacks begin, no double transition |
+| P1 tanks 30 s | boss swaps to P2 within the swap window |
+| P1 dies mid-fight | boss ignores body, retargets P2 instantly |
+| Kill boss | bar fades + banner on both; gates open; souls to both; spawner flag set (no respawn after rest) |
+
+---
+
+## Chapter checklist
+
+- [ ] Encounter state (ActiveBoss, BossFightState) replicated via GameState; late-join safe
+- [ ] `BP_BossEncounter` choreographer: gates, intro, defeat, rewards for all
+- [ ] Attack data table + weighted/cooldown pick task
+- [ ] Phase 2 at 50% with transition montage & interrupt-safe BT
+- [ ] Telegraph notifies (client-side VFX), punishable recoveries
+- [ ] Co-op target-swap + downed-player rules
+- [ ] Boss bar bound through GameState dispatcher
+
+**Next:** [Chapter 10 — Bonfires, Death & Souls](10-bonfires-death-souls.md)

--- a/guides/coop-soulslike-ue5/10-bonfires-death-souls.md
+++ b/guides/coop-soulslike-ue5/10-bonfires-death-souls.md
@@ -1,0 +1,169 @@
+# Chapter 10 — Bonfires, Death & Souls
+
+> **Goal of this chapter:** the soulslike loop — earn souls, rest at bonfires (heal + world reset), die and drop your souls, run back to recover them — working for every player in the session, and surviving a save/reload.
+
+---
+
+## 10.1 The loop
+
+```mermaid
+flowchart LR
+    K[Kill enemies] -->|souls to PlayerState| S((Souls))
+    S --> REST["Rest at bonfire:<br/>heal, refill flasks,<br/>set respawn point,<br/>WORLD RESETS<br/>(enemies respawn)"]
+    S --> SPEND[Spend: level up /<br/>buy — later]
+    K --> DIE[Death]
+    DIE -->|souls drop at<br/>death spot| BS[Bloodstain actor]
+    DIE --> RESPAWN[Respawn at<br/>last bonfire]
+    RESPAWN --> RECOVER{Reach bloodstain<br/>without dying again?}
+    RECOVER -- yes --> S
+    RECOVER -- no, died again --> GONE[Old souls lost forever,<br/>new bloodstain replaces it]
+```
+
+## 10.2 Where the data lives (co-op changes everything here)
+
+Single-player tutorials put souls on the character and reload the level on death. **Neither works in co-op**: pawns are destroyed/respawned (souls would vanish), and you cannot reload the level because *the other players are still playing in it*.
+
+| Data | Home | Why |
+|---|---|---|
+| `Souls` (int) | **PlayerState** (RepNotify) | survives pawn death; visible to party UI |
+| `LastBonfireID` (Name) | PlayerState (replicated) | per-player respawn point (souls-accurate) |
+| Bloodstain (location + amount) | **a replicated actor** in the world | everyone can see it; survives your respawn |
+| World flags (boss defeated, gates open, bonfires lit) | **GameState** (replicated arrays) + SaveGame | shared world truth |
+| Save file | **host's** SaveGame object | the host *is* the world (see 10.7) |
+
+**Death in co-op = respawn, not reload.** The Elden Ring "Seamless Co-op" mod uses exactly this model (die → respawn at your grace, session continues), and it's the right architecture for a built-for-co-op game. Chapter 11 adds the downed/revive layer *in front* of death for bosses.
+
+## 10.3 Interaction system (needed by bonfires, bloodstains, gates)
+
+`AC_Interaction` on `BP_PlayerCharacter` + interface `BPI_Interactable` (`GetPrompt() → text`, `CanInteract(Character) → bool`, `Interact(Character)` — Interact runs on the **server**).
+
+```text
+[AC_Interaction, local player only, Timer 0.15s]
+ → [Sphere Overlap (r=180) → nearest BPI_Interactable where CanInteract]
+ → [Show/Hide WBP_Prompt ("E — Rest at bonfire")]      ◄ purely local UI
+
+[IA_Interact Triggered]
+ → [Branch: FocusedInteractable valid]
+ → [Server_Interact(FocusedInteractable)]     (Run on Server, Reliable —
+                                               on the CHARACTER: we own it)
+[Server_Interact (Target)]
+ → [Branch: Target.CanInteract(me)]           ◄ server re-validates (range too!)
+ → [Target.Interact(me)]
+```
+
+This is the Ch. 2 ownership lesson in practice: the RPC goes through *your own character*, with the bonfire passed as a parameter.
+
+## 10.4 The bonfire
+
+`BP_Bonfire` (Actor, `Replicates = ON`) in `World/`: mesh, Niagara fire, `BonfireID (Name)`, `bIsLit (RepNotify)` → OnRep toggles the fire VFX (late joiners see lit bonfires correctly — state, not event!).
+
+`Interact(Character)` — server:
+
+```text
+1. [Branch: bIsLit == false] → [Set bIsLit (w/Notify) = true]   ◄ first touch lights it
+2. [Character.PlayerState.LastBonfireID = BonfireID]
+3. [GameMode.RestAtBonfire(instigating Character)]:
+     a. FOR EACH player character (alive ones):        ◄ souls rule: rest heals
+        heal to full, refill flasks                      the whole party
+     b. FOR EACH BP_EnemySpawner: ResetSpawner()       ◄ destroy live enemy,
+                                                         respawn fresh (skips
+                                                         bDefeated bosses)
+     c. [SaveWorld] (10.7)
+4. [Multicast_BonfireRest] → local: sit montage per resting player, screen fade,
+                              "Bonfire lit" banner if newly lit
+```
+
+> Design choice to make now: does resting **teleport the whole party** to the bonfire (prevents "one player rests while others fight" exploits — enemies respawn on their heads)? Simplest co-op-safe rule: resting requires no enemies aggro'd on any player (`all threat maps empty`), heals everyone in place. Ship that; revisit later.
+
+## 10.5 Souls: earning and spending
+
+From Ch. 8, enemies call `GameMode.AwardSouls(KillerController, Value)`:
+
+```text
+[GameMode.AwardSouls]   (server — GameMode is server-only, always safe)
+ → in co-op, award to ALL players (full to killer, or 100%/100% like
+   Seamless Co-op — recommended: everyone gets full value; shared-progress
+   co-op dies when friends compete for kills)
+ → [PlayerState.Souls (w/Notify) += Value]
+
+[PlayerState.OnRep_Souls] → dispatcher → HUD souls counter ticks up
+```
+
+Spending (level-up at bonfire, vendors) is the same pattern in reverse with a server-side `TrySpendSouls(Cost) → bool`. A minimal level-up: bonfire menu (local UI) → `Server_LevelUp(StatChoice)` → validate cost `= f(Level)` → increment stat in PlayerState, apply to `AC_Stats` (`MaxHealth`, etc. — replicated, so everyone sees your fatter HP bar).
+
+## 10.6 Death, bloodstains, recovery
+
+`BP_Bloodstain` (Actor, `Replicates = ON`): Niagara glow, `Amount (int)`, `OwnerPlayerID (replicated)` — **only the owner can recover it** (souls rule), but everyone sees it.
+
+In `GameMode.NotifyPlayerDied(Controller)` (hooked in Ch. 5):
+
+```text
+(server)
+1. [PS = Controller.PlayerState]
+2. [Branch: PS.Souls > 0]
+   → [Destroy PS.CurrentBloodstain if valid]     ◄ died again: old souls GONE
+   → [Spawn BP_Bloodstain at death location (trace down to floor)]
+       Amount = PS.Souls, OwnerPlayerID = PS.PlayerId
+   → [PS.CurrentBloodstain = it] ; [PS.Souls (w/Notify) = 0]
+3. [Start respawn timer 4s]  → [RespawnPlayer(Controller)]:
+   → [Find BP_Bonfire with BonfireID == PS.LastBonfireID]
+     (fallback: PlayerStart)
+   → [Spawn new BP_PlayerCharacter at bonfire + offset] → [Possess]
+   → HUD rebinds dispatchers on possess (Ch. 5 warning pays off here)
+```
+
+Bloodstain `Interact` (via `CanInteract`: `Character.PlayerState.PlayerId == OwnerPlayerID`):
+
+```text
+(server) [PS.Souls += Amount] → [PS.CurrentBloodstain = null] → [Destroy Actor]
+ → [Client_RecoveredSouls]  → local chime + VFX
+```
+
+> **"YOU DIED":** in `OnRep_bIsDead` (Ch. 5), if locally controlled → the fade-in banner widget. Client-side, free, and every player gets their own private doom screen while the others keep fighting.
+
+## 10.7 Saving (host-authoritative)
+
+Co-op save rule (copy Lords of the Fallen / Seamless Co-op): **the host's world is the world.** The save file records world + host progress; joiners keep their own PlayerState-level progress (souls, level) in their own save, synced into PlayerState on join.
+
+`BP_SG_World` (SaveGame class): `LitBonfireIDs (Name array)`, `DefeatedBossIDs`, `OpenedDoorIDs`, and per-player map `PlayerId → (Souls, Level, LastBonfireID, BloodstainTransform/Amount)`.
+
+```text
+[GameMode.SaveWorld]  (server; call on bonfire rest + on player leave + on shutdown)
+ → [Create Save Game Object (BP_SG_World)] (or reuse cached one in GameInstance)
+ → fill from GameState / actors / PlayerStates
+ → [Async Save Game to Slot "World_" + SlotName, UserIndex 0]
+
+[GameMode.LoadWorld]  (server, on map BeginPlay)
+ → [Does Save Game Exist] → [Load Game from Slot] → apply:
+     bonfires: set bIsLit (w/Notify) — RepNotify repaints them everywhere
+     bosses:   spawners with saved IDs set bDefeated (no spawn)
+     bloodstains: respawn saved ones
+```
+
+Everything applied on load is *replicated state*, so clients (who never load anything) still see the correct world. This is why the guide kept insisting on state over events.
+
+## 10.8 Test matrix (2 players, One-Process OFF for the join test)
+
+| Test | Expected |
+|---|---|
+| P2 kills enemy | both souls counters update (shared full award) |
+| P2 dies with 500 souls | bloodstain visible to both; P2 respawns at their last bonfire; P2 souls = 0 |
+| P1 tries to loot P2's stain | prompt doesn't appear (CanInteract false) |
+| P2 recovers own stain | +500, stain gone on both screens |
+| P2 dies twice | first stain vanished, only newest exists |
+| Rest at bonfire | both healed; enemies respawn on both screens; defeated boss doesn't |
+| Host quits to menu, re-hosts, P2 rejoins | lit bonfires, dead boss, bloodstains all restored |
+
+---
+
+## Chapter checklist
+
+- [ ] Interaction system (interface + server validation through own character)
+- [ ] Bonfire: lit state (RepNotify), party heal, spawner reset, save
+- [ ] Souls on PlayerState; award/spend server-side; HUD counter
+- [ ] Death → owner-locked replicated bloodstain → respawn at own bonfire (no level reload!)
+- [ ] Die-again rule destroys the old stain
+- [ ] Host-authoritative world save/load; late joiners see restored state
+- [ ] Test matrix passes
+
+**Next:** [Chapter 11 — Co-op Systems: Revive, Scaling & Party UX](11-coop-polish.md)

--- a/guides/coop-soulslike-ue5/11-coop-polish.md
+++ b/guides/coop-soulslike-ue5/11-coop-polish.md
@@ -1,0 +1,135 @@
+# Chapter 11 — Co-op Systems: Revive, Scaling & Party UX
+
+> **Goal of this chapter:** the systems that make it a *co-op* soulslike rather than a soulslike that tolerates guests: downed/revive, enemy scaling by player count, party HUD, and the drop-in/drop-out rules. This is also where you make the design calls — reference numbers from shipped games included.
+
+---
+
+## 11.1 Design decisions (make them explicitly)
+
+| Question | Souls-classic (ER vanilla) | Built-for-co-op (recommended) |
+|---|---|---|
+| Session model | summon per boss area, ends on boss/host death | persistent drop-in/out session (our Ch. 3 already does this) |
+| Player death | phantom leaves / session ends | **downed → revive window → respawn at own bonfire** |
+| During boss | host death = wipe | dead player spectates; wipe only when ALL players down (Seamless Co-op / Nioh 2 model) |
+| Loot & souls | host-favored | everyone gets 100% (LotF 2.0 moved to this after launch backlash — learn from them) |
+| Enemy HP | +60%/+130% (boss, per phantom) | +35–50% per extra player, bosses more |
+| World progress | host only | host-authoritative save (Ch. 10), joiners keep character progress |
+
+The recommended column is what this chapter builds.
+
+## 11.2 Downed & revive
+
+The flow (mirrors Remnant 2's bleed-out, the best-in-class version):
+
+```mermaid
+stateDiagram-v2
+    Alive --> Downed : HP reaches 0<br/>(instead of dying)
+    Downed --> Alive : ally holds Interact 3s<br/>revived at 30% HP
+    Downed --> Dead : bleed-out (60s) expires<br/>or enemy damage drains it<br/>or all players downed
+    Dead --> Alive : respawn at own bonfire (Ch. 10)<br/>(boss fight: spectate until fight ends)
+    note right of Downed
+        Downed player: crawl slowly, no actions,
+        visible bleed-out bar to whole party.
+        Enemies ignore them (threat cleared).
+    end note
+```
+
+### Implementation
+
+`AC_Stats` changes (server): in `ReceiveDamage`, when `Health` would hit 0 and `bCanBeDowned` (true in multi-player sessions, false solo — solo goes straight to Ch. 10 death):
+
+```text
+[Set CombatState (w/Notify) = Downed] ; [Set Health = 1]
+[Set BleedOut (RepNotify float) = 60.0]     ◄ party UI shows it
+[Clear this player from all enemy threat maps]  (Ch. 8.6)
+[Server timer 1s loop: BleedOut -= 1 (further hits: -5 extra);
+   at 0 → GameMode.NotifyPlayerDied (Ch. 10 death: bloodstain etc.)]
+```
+
+`OnRep_CombatState == Downed`, locally controlled → crawl mode: `Max Walk Speed = 80`, disable attack/dodge inputs (gate them on CombatState — you already do), downed camera + desaturation post-process. Simulated proxies → crawl anim via the AnimBP reading CombatState.
+
+**Revive** is just an interactable: the downed character's `BPI_Interactable.CanInteract` returns true for *other living players*; prompt "Hold E — Revive". Hold-to-interact: `IA_Interact` with a **Hold (3 s)** trigger, or a server-side channel (start on press RPC, cancel on release RPC, complete on 3 s timer — server-side channel is cheat-proof and lag-honest; use it):
+
+```text
+[Server: ReviveComplete]
+ → [Downed.AC_Stats: Health = MaxHealth * 0.3 (w/Notify)]
+ → [CombatState (w/Notify) = Idle] ; [stop bleed-out timer]
+ → [1s of bInvincible]              ◄ Remnant 2 added post-revive i-frames
+                                      in a patch for a reason: revive-camping
+ → [Multicast: revive VFX/anim]
+```
+
+**Wipe rule** (server, checked whenever someone goes down): if **all** connected players are Downed or Dead → everyone gets Ch. 10 death treatment (bloodstains at their spots, respawn at bonfires), world does a bonfire-style reset, boss (if active) resets to full and `BossFightState = None`. During a boss fight, dead players **spectate** (set view target to a living ally: `Set View Target with Blend`, owning-client RPC) instead of respawning — respawn-running back into a boss arena mid-fight breaks the fight's tension and its gate logic.
+
+## 11.3 Enemy scaling by player count
+
+One function on the GameMode, called when spawning any enemy *and* when player count changes (for already-alive enemies, scale MaxHealth but keep Health fraction):
+
+```text
+[GameMode.GetEnemyScalars → (HPMult, DmgMult)]
+ N = alive connected players
+ HPMult  = 1.0 + 0.5 * (N - 1)        ◄ regular enemies: +50%/extra player
+ BossHP  = 1.0 + 0.65 * (N - 1)       ◄ Elden Ring: ×1.6 @2p, ×2.3 @3p
+ DmgMult = 1.0 + 0.15 * (N - 1)       ◄ damage scales gently (Remnant 2
+                                         nerfed 25%→15% per player; spikes
+                                         feel unfair in melee)
+```
+
+Apply in `BP_EnemySpawner` / boss spawn: `AC_Stats.MaxHealth *= HPMult`, weapon damage `*= DmgMult`. Also scale **attack tokens**: `MaxTokens` on each player stays 2, which already means more total simultaneous attacks with more players — usually enough; don't double-scale.
+
+**Mid-session join/leave:** hook `GameMode → Event OnPostLogin` and `Event OnLogout`. On join: spawn their pawn at the *host's* last bonfire, sync their PlayerState from their own save, rescale living enemies. On leave: rescale, and if they were mid-fight, remove from threat maps; save the world (their bloodstain persists in the host's save — they can recover it next session).
+
+## 11.4 Party HUD
+
+`WBP_PartyList` in the HUD: one row per *other* player — name, HP bar, downed state/bleed-out, distance arrow.
+
+Data source pattern (no polling, no RPCs — everything is already replicated):
+
+```text
+[GameState.PlayerArray]           ◄ engine-maintained, replicated list of
+                                    every PlayerState
+ → on change (poll 1s or bind to PostLogin/Logout via GameState dispatchers
+   you fire from GameMode → replicated event): rebuild rows
+Each row:
+ → [PS.GetPawn → AC_Stats.OnHealthChanged]  → HP bar
+ → [PS.OnRep_Souls dispatcher]              → souls (optional)
+ → [CombatState == Downed]                  → row flashes red + bleed-out bar
+                                              + on-screen marker ("go revive!")
+```
+
+Off-screen ally/downed markers: `Project World to Screen` on the ally each frame; if off-screen, clamp to screen edge and rotate an arrow — this is a self-contained widget, grab any "off-screen indicator" tutorial.
+
+**Ping system (strongly recommended, ~1 hour):** `IA_Ping` → line trace from camera → `Server_Ping(Location)` → multicast → everyone spawns a temporary marker widget/Niagara at the spot. In a game without voice chat, ping IS your communication system.
+
+## 11.5 Trivial-but-important co-op details
+
+- **Player collision:** players should *not* block each other (body-blocking in corridors = grief). Capsule → Pawn channel = **Ignore** between players (custom object channel `PlayerPawn`), but keep blocking enemies.
+- **Shared pickups:** items in the world (flask upgrades, key items) → give to **everyone** on pickup (Remnant 2 model: one player picks up, all receive). Consumable world drops can be per-player: replicate the pickup actor with a `TakenBy (PlayerId array)`; `CanInteract` false if your ID is in it; visually hide via OnRep for those who took it. Instanced loot without duplication drama.
+- **Flask (Estus):** per-player consumable on PlayerState (`FlasksRemaining`, RepNotify), refilled by bonfire rest; drinking = a montage with an `AN_Heal` notify → server heals — interruptible by damage, exactly like the dodge/attack patterns you already have.
+- **Friendly VFX readability:** tint ally attack VFX blue/green so players can parse a 4-body melee. Local-only cosmetic choice in the multicast handlers.
+
+## 11.6 Test matrix (this one earns its keep — 2–3 players, One-Process OFF, 120 ms)
+
+| Test | Expected |
+|---|---|
+| P2 HP to 0 in a mob fight | P2 downed, crawling; enemies switch to P1; party row flashes on P1's HUD |
+| P1 revives P2 (hold 3 s) | interrupted if P1 releases early or gets hit; success → P2 at 30% + 1 s i-frames |
+| P2 bleeds out | normal death: bloodstain, respawn at P2's bonfire |
+| All players down | wipe: world reset, boss reset, everyone at bonfires |
+| P2 downed during boss, bleeds out | P2 spectates P1; if P1 wins, P2 respawns; if P1 wipes, both respawn |
+| 3rd player joins mid-session | spawns at host bonfire; enemy HP rescales; party list updates everywhere |
+| Player leaves mid-fight | enemies rescale + retarget; no dangling threat/tokens (watch for the circling-forever bug) |
+| Pickup a key item | everyone gets it; per-player consumable hides only for the taker |
+
+---
+
+## Chapter checklist
+
+- [ ] Downed/bleed-out/revive with server-side hold channel + post-revive i-frames
+- [ ] Wipe rule + boss spectating
+- [ ] Player-count scaling (HP heavy, damage light) incl. mid-session join/leave
+- [ ] Party HUD rows off replicated state only; downed markers; ping
+- [ ] Player-player collision off, shared key items, per-player flasks
+- [ ] Full matrix with 3 real processes
+
+**Next:** [Chapter 12 — Packaging, Performance & the Road to C++](12-packaging-and-beyond.md)

--- a/guides/coop-soulslike-ue5/12-packaging-and-beyond.md
+++ b/guides/coop-soulslike-ue5/12-packaging-and-beyond.md
@@ -1,0 +1,107 @@
+# Chapter 12 — Packaging, Performance & the Road to C++
+
+> **Goal of this chapter:** shippable builds your friends can actually playtest, the network/perf tuning pass, and a concrete map of *which* systems to migrate to C++ (and GAS) when you're ready — in priority order, not all at once.
+
+---
+
+## 12.1 Packaging a build
+
+1. **Project Settings → Packaging**: Build Configuration = *Development* for playtests (*Shipping* hides logs/console — save it for release), tick *Use Pak File*.
+2. **Project Settings → Maps & Modes**: confirm Game Default Map = `L_MainMenu`; **Packaging → List of maps to include** — include all your maps (missing-map crashes on travel are a classic).
+3. Platforms → Windows → **Package Project**. First build takes ages (shader compile); later ones are incremental.
+4. Test the *packaged* build with two machines (or two copies on one machine with `-windowed`): host, join, play 15 minutes. PIE hides packaged-only bugs: missing maps, case-sensitive paths, plugin not packaged, Steam-only behavior.
+
+**Playtest distribution:** zip the `Windows/` output folder; or Steam Playtest if you have an AppId. Remember Ch. 3: Steam features need Steam running and a packaged build.
+
+## 12.2 Network performance pass
+
+At 4 players your bandwidth is almost certainly fine, but do this once before wide playtesting:
+
+| Action | How | Payoff |
+|---|---|---|
+| Watch the numbers | `stat net` in a packaged build while 4p fighting | know your baseline (aim well under 100 KB/s per client) |
+| Slow down quiet actors | `Net Update Frequency` = 5–10 on doors, bonfires, pickups (default 100) | most replication cost is pawns; keep it that way |
+| Dormancy for set-and-forget state | `Net Dormancy = Dormant All` on bonfires/doors; call `Flush Net Dormancy` before changing their replicated vars | near-zero cost when idle |
+| Relevancy distance | pawns/enemies: default relevancy is fine; big levels → consider `Net Cull Distance Squared` on enemies (e.g. 15000²) | joins/leaves of far actors handled by engine |
+| Don't replicate cosmetics | audit: VFX, widgets, camera vars marked Replicated by accident | free wins |
+| Unreliable where possible | hit-react/dodge multicasts unreliable; only state-critical RPCs reliable | avoids reliable-buffer overflow kicks |
+| Test the worst case | 4 players + 6 enemies + boss, 150 ms + 1% loss emulation | if this is playable, you're done |
+
+**The listen-server host advantage** (host has 0 ping) is fine in co-op — nobody's competing. The host's machine does pay for server + rendering; your minimum-spec machine should host in at least one playtest.
+
+## 12.3 General performance quick hits
+
+- `stat unit` (is it Game, Draw, or GPU bound?), `stat scenerendering`, Unreal Insights for deep dives.
+- Animation: enable **Update Rate Optimization** on enemy skeletal meshes + `Visibility Based Anim Tick Option = Only Tick Poses when Rendered` (careful: keep montage-driven *damage windows* server-ticking — server has no rendering; use `Always Tick Pose and Refresh Bones` on the server if traces misbehave — gate with `Is Dedicated Server`/has-authority checks).
+- AI: Behavior Tree services at 0.5–1 s intervals, not Tick; perception dominant sense only Sight until you need more.
+- Niagara: pool impact effects (spawn-once systems, user-param reuse), cap simultaneous blood systems.
+- UI: no `Bind` property bindings that poll per frame (you built everything event-driven — keep it that way).
+
+## 12.4 The road to C++ — what, why, and in what order
+
+Blueprints will carry this project a long way (everything in this guide ships fine as BP). Add C++ **surgically**, when you feel a specific pain. Enabling it is non-destructive: *Tools → New C++ Class* converts the project; Blueprints then *inherit from* your C++ classes and keep working.
+
+```mermaid
+flowchart TD
+    P1["PAIN: tick-heavy math<br/>(traces, threat, lock-on scoring)<br/>is slow or spaghetti"] --> S1["C++ step 1:<br/>rewrite AC_Stats & trace loop as C++<br/>UActorComponents; BPs subclass them.<br/>Same design, 10× perf, cleaner diffs"]
+    P2["PAIN: ability logic sprawling —<br/>cost/cooldown/interrupt/buff code<br/>duplicated across dodge/attack/flask"] --> S2["C++ step 2: adopt GAS<br/>(GameplayAbilitySystem)"]
+    P3["PAIN: root-motion drift, dodge<br/>prediction edge cases at high ping"] --> S3["C++ step 3: GAS ability tasks<br/>(PlayMontageAndWait replicates montages<br/>+ prediction keys), Motion Warping,<br/>Root Motion Sources"]
+    P4["PAIN: want dedicated servers"] --> S4["C++ step 4: source-built engine,<br/>server target, deploy headless Linux"]
+    S1 --> S2 --> S3 --> S4
+```
+
+### About GAS (read before you're tempted)
+
+The **Gameplay Ability System** is Epic's networked ability framework (Lyra, Fortnite): abilities with built-in replication, prediction, costs, cooldowns, gameplay tags, and attribute sets. It would replace the hand-rolled parts of Ch. 4–6 (`Server_Dodge` RPCs, stamina checks, montage multicasts) with `GA_Dodge`, `GA_LightAttack`, a `GE_StaminaCost`…
+
+Facts to plan around (from the community-standard GASDocumentation):
+
+- **GAS cannot be set up in pure Blueprint.** The AbilitySystemComponent and **AttributeSets are C++-only**; abilities and effects can then be authored in BP. Expect a thin C++ layer (~a few hundred lines) or a bridge plugin (*GAS Companion* (paid), *GAS Associate* (free), *Blueprint Attributes*) if you want it earlier.
+- Its killer feature for this genre: `PlayMontageAndWait` ability tasks replicate montages **with prediction** — the exact thing we hand-built for the dodge — plus tag-based interrupt rules (`State.Staggered` blocks `Ability.Attack`) that replace the CombatState enum with something far more composable.
+- Migration path that works: keep `AC_Stats`/`AC_Combat` interfaces (dispatchers, function names) and reimplement their guts on GAS — UI and AI don't need to know.
+
+**Recommendation:** ship your vertical slice on this guide's architecture first. You'll then understand *exactly* what GAS is solving, and the migration is a refactor, not a leap of faith.
+
+### What should stay Blueprint forever
+
+UI, level scripting (`BP_BossEncounter`), data assets, AnimBPs/montage notifies wiring, VFX/audio hookup, one-off interactables. C++ is for hot loops, framework classes, and things needing engine features BP can't reach.
+
+## 12.5 Content roadmap after the systems are done
+
+You now have every *system* a co-op soulslike needs. What remains is content and iteration:
+
+```mermaid
+gantt
+    dateFormat X
+    axisFormat %s
+    title From systems-complete to vertical slice (relative effort, not weeks)
+    section Content
+    Blockout dungeon L_Dungeon01 (shortcuts! loops!)  :a1, 0, 3
+    3 enemy types from BP_EnemyBase                    :a2, 1, 3
+    Boss 1 polish (anims, arena, music)                :a3, 2, 3
+    section Feel
+    Anim set upgrade (Fab packs / GASP retarget)       :b1, 2, 2
+    SFX + hit VFX pass                                 :b2, 3, 2
+    Camera polish (lock-on tuning at scale)            :b3, 3, 1
+    section Meta
+    Level-up + weapon upgrade loop                     :c1, 3, 2
+    4-player playtests, weekly                         :c2, 0, 6
+```
+
+Level design notes specific to the genre: design around **loops and shortcuts** (bonfire → route → unlockable shortcut back), place bonfires so a death costs 2–4 minutes of run-back, and playtest widths — co-op melee needs corridors ~1.5× wider than solo would.
+
+## 12.6 Where to go deeper
+
+The [Resources appendix](resources.md) collects every doc, tutorial series, sample repo, and plugin referenced across the guide, with notes on what each is good for.
+
+---
+
+## Chapter checklist
+
+- [ ] Development-config packaged build; 2-machine host/join test passed
+- [ ] `stat net` baseline recorded; quiet actors dormant/slowed
+- [ ] Worst-case fight tested at 150 ms + loss
+- [ ] You know your C++ trigger points (and are ignoring GAS until the slice ships)
+- [ ] Content roadmap drafted; weekly playtests scheduled
+
+**You made it.** Systems-complete is the hard half of a soulslike. Now go build a dungeon worth dying in — repeatedly, with friends.

--- a/guides/coop-soulslike-ue5/README.md
+++ b/guides/coop-soulslike-ue5/README.md
@@ -110,4 +110,4 @@ Diagrams are [Mermaid](https://mermaid.js.org/) and render directly on GitHub.
 
 ---
 
-*Written July 2026 against UE 5.4–5.6. Sources and further reading: [resources.md](resources.md).*
+*Written July 2026 against UE 5.4–5.6; current stable at time of writing is 5.8, and everything here uses core 5.x systems that are unchanged in it. UE6 is announced (May 2026) but years from usable — build on UE5. Sources and further reading: [resources.md](resources.md).*

--- a/guides/coop-soulslike-ue5/README.md
+++ b/guides/coop-soulslike-ue5/README.md
@@ -1,0 +1,113 @@
+# Building a Co-op Soulslike in Unreal Engine 5 — A Step-by-Step Guide
+
+A 12-chapter, Blueprint-first implementation guide for a 2–4 player online co-op soulslike (listen server, drop-in sessions, souls-style combat/death loop), written to be followed in order. C++ is deliberately deferred — [Chapter 12](12-packaging-and-beyond.md) maps the migration path when you're ready.
+
+> **The one rule the whole guide is built on:** every feature is designed server-authoritative and tested with 2+ clients *from day one*. Multiplayer is not a layer you add later.
+
+---
+
+## What you'll have at the end
+
+- Host / find / join sessions (LAN → Steam), drop-in/drop-out
+- A networked player character: sprint & stamina, root-motion dodge with i-frames, lock-on targeting
+- Melee combat: combo chains, input buffering, animation-driven weapon traces, poise & stagger, hit reactions, hitstop
+- Enemies on Behavior Trees with perception, threat tables, and soulslike **attack tokens**; a two-phase boss behind a fog gate
+- The full souls loop: bonfires (heal + world reset), souls currency, death → bloodstain → corpse-run recovery
+- Co-op systems: downed/bleed-out/revive, wipes, spectating, enemy scaling by player count, party HUD, shared loot rules
+- Packaged builds, a network performance pass, and a prioritized C++/GAS adoption plan
+
+## Chapters
+
+| # | Chapter | You build |
+|---|---|---|
+| 1 | [Project Setup & Foundations](01-project-setup.md) | Project, framework classes, folders, source control, 2-player PIE |
+| 2 | [Multiplayer Foundations](02-multiplayer-foundations.md) | The mental model: authority, roles, RPCs, RepNotify — plus a hands-on test |
+| 3 | [Sessions: Hosting & Joining](03-sessions-and-joining.md) | Main menu, Create/Find/Join, Steam config, Advanced Sessions |
+| 4 | [Locomotion, Stamina & Dodge](04-character-locomotion.md) | AC_Stats, sprint, predicted root-motion dodge, i-frames, combat state machine |
+| 5 | [Stats & the Damage Pipeline](05-stats-and-damage.md) | Health/poise, one server-side damage pipeline, hit reactions, death, HP bars |
+| 6 | [Melee Combat](06-melee-combat.md) | Weapons + data tables, combos, input buffering, notify-driven weapon traces |
+| 7 | [Lock-On Targeting](07-lock-on.md) | Client-local targeting, camera, switching, strafe mode |
+| 8 | [Enemy AI & Group Combat](08-enemy-ai.md) | BT/perception, attack tokens, co-op threat tables, spawners |
+| 9 | [The Boss Fight](09-boss.md) | Encounter state, fog gate, phases, telegraphs, boss bar |
+| 10 | [Bonfires, Death & Souls](10-bonfires-death-souls.md) | Interaction system, bonfire rest/reset, bloodstains, host-authoritative saves |
+| 11 | [Co-op Systems](11-coop-polish.md) | Downed/revive, wipe rules, player-count scaling, party HUD, ping |
+| 12 | [Packaging & the Road to C++](12-packaging-and-beyond.md) | Builds, net perf pass, C++/GAS migration map |
+| A | [Resources appendix](resources.md) | Every doc, tutorial, sample repo, plugin & book, annotated |
+
+## System dependency map
+
+Chapters are ordered so each system stands on finished ones:
+
+```mermaid
+flowchart TD
+    C1[1 Setup] --> C2[2 Replication model]
+    C2 --> C3[3 Sessions]
+    C2 --> C4[4 Stamina + Dodge]
+    C4 --> C5[5 Damage pipeline]
+    C5 --> C6[6 Melee combat]
+    C4 --> C7[7 Lock-on]
+    C6 --> C8[8 Enemy AI]
+    C8 --> C9[9 Boss]
+    C5 --> C10[10 Bonfires + Souls]
+    C8 --> C10
+    C9 --> C11[11 Co-op: revive, scaling]
+    C10 --> C11
+    C3 --> C11
+    C11 --> C12[12 Ship it / C++]
+    style C2 fill:#1e5a8a,color:#fff
+    style C5 fill:#1e5a8a,color:#fff
+    style C11 fill:#1e5a8a,color:#fff
+```
+
+The blue nodes are the load-bearing ones: the replication model (Ch. 2), the single damage pipeline (Ch. 5), and the co-op layer (Ch. 11). Skimp anywhere but there.
+
+## Suggested pacing
+
+Working evenings/weekends, each chapter is roughly a week; Chapters 6 and 11 are closer to two. A dedicated month gets you through Chapter 8. Don't rush Chapter 2 — it's an hour of reading that saves a month of rewrites.
+
+```mermaid
+gantt
+    dateFormat X
+    axisFormat wk %s
+    title Rough relative effort (1 unit ≈ a hobby week)
+    section Foundations
+    Ch 1-2 Setup + netcode model      :0, 2
+    Ch 3 Sessions                     :2, 1
+    section Combat core
+    Ch 4 Movement/stamina/dodge       :3, 1
+    Ch 5 Damage pipeline              :4, 1
+    Ch 6 Melee combat                 :5, 2
+    Ch 7 Lock-on                      :7, 1
+    section World
+    Ch 8 Enemy AI                     :8, 2
+    Ch 9 Boss                         :10, 1
+    Ch 10 Bonfires/souls              :11, 1
+    section Co-op & ship
+    Ch 11 Revive/scaling/party        :12, 2
+    Ch 12 Package + perf              :14, 1
+```
+
+## How to read the code examples
+
+Blueprints don't paste into Markdown, so graphs are written as structured pseudocode. `[Square brackets]` are nodes (using exact node names from the palette — e.g. `Multi Sphere Trace For Objects`, `RInterp To`, `Montage Jump to Section`), indentation is execution flow, and `◄` comments explain the *why*:
+
+```text
+[IA_SprintDodge Triggered(Tap)]              ◄ Enhanced Input action event
+ → [Branch: CombatState == Idle]             ◄ the state machine gates everything
+     True → [Play Anim Montage: AM_DodgeRoll]
+          → [Server_Dodge]                   ◄ custom event, Replicates = Run on Server
+```
+
+Every replicated variable, RPC direction, and reliability flag is spelled out — those details *are* the tutorial.
+
+Diagrams are [Mermaid](https://mermaid.js.org/) and render directly on GitHub.
+
+## Prerequisites
+
+- UE5 installed and basic editor literacy (place actors, open Blueprints). If Blueprints are brand new to you, do Epic's free "Your First Hour in Unreal Engine 5" course first — this guide assumes you can wire nodes.
+- No C++, no networking background required — Chapter 2 teaches the networking from zero.
+- A friend (or a second monitor) to playtest with. Non-negotiable, and the fun part.
+
+---
+
+*Written July 2026 against UE 5.4–5.6. Sources and further reading: [resources.md](resources.md).*

--- a/guides/coop-soulslike-ue5/resources.md
+++ b/guides/coop-soulslike-ue5/resources.md
@@ -1,0 +1,100 @@
+# Appendix — Resources, Cookbooks & Sample Code
+
+Everything referenced across the guide, plus the best of what's out there, organized by topic. ⭐ = start here for that topic.
+
+---
+
+## Multiplayer & replication
+
+| Resource | What it's for |
+|---|---|
+| ⭐ **Cedric "eXi" Neukirchen — Multiplayer Network Compendium** — https://cedric-neukirchen.net/docs/category/multiplayer-network-compendium/ (Epic-hosted mirror: https://dev.epicgames.com/community/learning/tutorials/jO9e/multiplayer-network-compendium) | THE community reference for everything in Chapter 2 — class table, RPCs, ownership, sessions. Read it once fully. |
+| Epic docs — Networking Overview — https://dev.epicgames.com/documentation/en-us/unreal-engine/networking-overview | Official entry point |
+| Epic docs — Replicate Actor Properties — https://dev.epicgames.com/documentation/unreal-engine/replicate-actor-properties-in-unreal-engine | Variable replication & RepNotify details |
+| Epic docs — Remote Procedure Calls — https://dev.epicgames.com/documentation/unreal-engine/remote-procedure-calls-in-unreal-engine | RPC rules (ownership, reliability) |
+| Epic docs — Networked Movement in CMC — https://dev.epicgames.com/documentation/unreal-engine/understanding-networked-movement-in-the-character-movement-component-for-unreal-engine | Net roles + the canonical source on root-motion networking |
+| **WizardCell — Multiplayer Tips and Tricks** — https://wizardcell.com/unreal/multiplayer-tips-and-tricks/ | Dense gotcha list (OnRep quirks, ownership) |
+| **Vorixo — Correct stateful replication** — https://vorixo.github.io/devtricks/stateful-events-multiplayer/ | The "state vs events / late joiners" rule of Ch. 2.5, argued properly |
+| **Kekdot (YouTube)** — https://www.youtube.com/watch?v=OVeo3cVTIcU (Basics of Replication) | Best video channel for BP multiplayer; their RepNotify & sessions videos map to Ch. 2–3 |
+| droganaida/UE5-Multiplayer-Replication-Guide — https://github.com/droganaida/UE5-Multiplayer-Replication-Guide | Small BP replication/authority playground project |
+
+## Sessions, Steam & EOS
+
+| Resource | What it's for |
+|---|---|
+| Epic docs — Online Session Nodes — https://dev.epicgames.com/documentation/en-us/unreal-engine/online-session-nodes?application_version=4.27 | The Create/Find/Join/Destroy nodes (page is 4.27-era; nodes unchanged) |
+| ⭐ **Advanced Sessions Plugin** (mordentral) — https://github.com/mordentral/AdvancedSessionsPlugin + prebuilt binaries: https://vreue4.com/advanced-sessions-binaries | Server names, Steam friends/avatars/invites, session filters — Ch. 3.5. Prebuilt binaries work in BP-only projects; building from source needs C++. Disable the Steam Sockets plugin alongside it. |
+| Epic docs — Online Subsystem Steam — https://dev.epicgames.com/documentation/en-us/unreal-engine/online-subsystem-steam-interface-in-unreal-engine | The ini config in Ch. 3.5 |
+| Epic docs — Online Subsystem EOS — https://dev.epicgames.com/documentation/en-us/unreal-engine/online-subsystem-eos-plugin-in-unreal-engine + course: https://dev.epicgames.com/community/learning/courses/1px/unreal-engine-the-eos-online-subsystem-oss-plugin | The free crossplay alternative to Steam |
+| Epic community — Using EOS with Blueprints — https://dev.epicgames.com/community/learning/tutorials/Mbop/unreal-engine-using-epic-online-services-with-blueprints | BP-only EOS walkthrough |
+
+## Soulslike combat tutorials (Blueprint)
+
+| Resource | What it's for |
+|---|---|
+| ⭐ **Ali Elzoheiry (YouTube)** — combo system: https://www.youtube.com/watch?v=Q5xk5PYlQ1k ; Smart Enemy AI playlist: https://www.youtube.com/playlist?list=PLNwKK6OwH7eW1n49TW6-FmiZhqRn97cRy | The best BP series for this genre: combos, damage-info structs, group AI with **attack tokens** (Part 11), EQS strafing (Part 4), boss fights (Parts 20–22). Ch. 6/8/9 follow the same architecture. |
+| **UnrealRPGMastery — Soulslike Combat series** — https://www.youtube.com/watch?v=HWxS-oe0kTo ; full Udemy course: https://www.udemy.com/course/unreal-engine-5-soulslike-combat/ | Soup-to-nuts soulslike melee: stats component, combos, directional dodge, lock-on, hit detection, boss AI |
+| **Gorka Games — UE5 RPG series #12 (Target Lock & Dodge Roll)** — https://dev.epicgames.com/community/learning/tutorials/JXnb/unreal-engine-5-rpg-tutorial-series-12-target-lock-and-dodge-roll | Free text+video lock-on & roll matching Ch. 4/7 |
+| Epic community — Networked Dash (Root Motion) — https://dev.epicgames.com/community/learning/tutorials/WzoK/unreal-engine-networked-dash-root-motion | The Server→Multicast root-motion montage recipe (our dodge) |
+| Epic community — Dodge Roll with Root Motion — https://dev.epicgames.com/community/learning/tutorials/aVpz/how-to-make-a-dodge-roll-with-root-motion-in-unreal-engine-5 | Root-motion roll setup |
+| Epic community — Melee Trace (UE 5.5) — https://dev.epicgames.com/community/learning/tutorials/W4Pz/melee-trace-unreal-engine-5-5 | AnimNotifyState weapon-trace pattern (Ch. 6.4) |
+| **MeleeTrace plugin** — https://github.com/rlewicki/MeleeTrace | Free, production-quality socket-interpolated melee traces (needs C++ project to build) |
+| Epic community — Simple Hitstop — https://dev.epicgames.com/community/learning/tutorials/Rek5/simple-hitstop-implementation | Ch. 5.4's juice |
+| **mklabs Target System plugin** — https://github.com/mklabs/ue4-targetsystemplugin | Open-source lock-on component; its LOS-delay & screen-space switching logic informed Ch. 7 |
+| 80.lv — Souls-like in UE5 writeup — https://80.lv/articles/tutorial-full-souls-like-game-in-unreal-engine-5 | Overview article with further links |
+
+## AI
+
+| Resource | What it's for |
+|---|---|
+| ⭐ Epic docs — Behavior Tree Quick Start — https://dev.epicgames.com/documentation/en-us/unreal-engine/behavior-tree-in-unreal-engine---quick-start-guide | Do this once before Ch. 8 |
+| Epic docs — BT Overview / Node Reference — https://dev.epicgames.com/documentation/en-us/unreal-engine/behavior-tree-in-unreal-engine---overview | Composites, decorators, observer aborts |
+| Epic docs — AI Perception — https://dev.epicgames.com/documentation/en-us/unreal-engine/ai-perception-in-unreal-engine | Sight config fields used in Ch. 8.2 |
+| Epic docs — EQS Quick Start — https://dev.epicgames.com/documentation/en-us/unreal-engine/environment-query-system-quick-start-in-unreal-engine | Donut-generator strafing (Ch. 8.5 fancy version) |
+| Gorka Games — Boss Fight BT tutorial — https://dev.epicgames.com/community/learning/tutorials/nwV6/how-to-create-a-boss-fight-in-unreal-engine-5-behavior-trees-ai-beginner-tutorial | Phase-switching boss BT |
+| Lim-Young/UnrealAITokenSystem — https://github.com/Lim-Young/UnrealAITokenSystem | DOOM-style attack-token architecture (C++, maps 1:1 to Ch. 8.5) |
+| Ryan Laley — UE5 AI playlist — https://www.youtube.com/playlist?list=PL4G2bSPE_8uklDwraUCMKHRk2ZiW29R6e | Gentle full-course alternative for BT/perception |
+
+## Saves, bonfires, souls
+
+| Resource | What it's for |
+|---|---|
+| Epic docs — Saving and Loading Your Game — https://dev.epicgames.com/documentation/en-us/unreal-engine/saving-and-loading-your-game-in-unreal-engine | SaveGame object nodes (Ch. 10.7) |
+| Epic community (UNF Games) — Creating a Bonfire System — https://dev.epicgames.com/community/learning/tutorials/R4zX/unreal-engine-creating-a-bonfire-system | Bonfire menu, rest, world reset |
+| ⭐ **Tom Looman — Unreal Engine Save System** — https://tomlooman.com/unreal-engine-cpp-save-system/ | Explicitly Dark-Souls-styled world-state saving; C++ but the architecture is Ch. 10.7's blueprint |
+
+## Sample projects & frameworks
+
+| Resource | What it's for |
+|---|---|
+| ⭐ **Lyra Starter Game** (Epic, free) — https://dev.epicgames.com/documentation/en-us/unreal-engine/lyra-sample-game-in-unreal-engine | Epic's networked-GAS best-practice sample. Architecture reference for the C++/GAS era (Ch. 12), not a base to build on (C++-heavy shooter). |
+| **tranek/GASDocumentation** — https://github.com/tranek/GASDocumentation | The GAS bible + multiplayer sample. Read before any GAS decision. Key fact: ASC/AttributeSets require C++; abilities/effects can be BP. |
+| GAS Companion (paid) — https://gascompanion.github.io/ · GAS Associate (free) — https://forums.unrealengine.com/t/gas-associate-a-plugin-to-use-gameplay-ability-system-in-blueprints-free/635382 | GAS-without-writing-C++ bridge plugins |
+| Pyrrhulla/UE5_Melee_Soulslike- — https://github.com/Pyrrhulla/UE5_Melee_Soulslike- | All-Blueprint soulslike study project (lock-on, combos, stamina, dodge, boss) — readable reference |
+| georgehuan1994/Unreal-Melee-Combat-System — https://github.com/georgehuan1994/Unreal-Melee-Combat-System | UE5.1 BP soulslike combat; names match Ch. 4–6 patterns (`IFrame_ANS`, stat component, per-action costs) |
+| Makyrios/SoulsLikeGame — https://github.com/Makyrios/SoulsLikeGame | C++ soulslike matching Elzoheiry's architecture (StateManager/Combat/Targeting/Collision components) — your Ch. 12 migration preview |
+| felipenune/SoulsLike — https://github.com/felipenune/SoulsLike | The rare *multiplayer* soulslike course-repo (DevAdict's course) |
+| **ALS-Refactored** (Sixze) — https://github.com/Sixze/ALS-Refactored | Network-reliable locomotion framework if you outgrow the template's movement. C++; ALS v4 (BP, free on Fab) is unmaintained. Traversal only — no combat. |
+| Soulslike Framework (paid, Fab) — https://www.fab.com/listings/75455ba4-7407-45db-b24e-160712b9586c | Complete single-player soulslike kit — note: **no confirmed multiplayer support**; buying it does not skip this guide's networking work |
+| Blueprint sharing — https://blueprintue.com/ | Paste-bin for BP graphs (search "dodge", "lock on", "stamina"…) |
+
+## Books (Blueprint cookbooks)
+
+| Book | Notes |
+|---|---|
+| *Blueprints Visual Scripting for Unreal Engine 5*, 3rd ed. — Romero & Sewell (Packt) | Best current BP book; code: https://github.com/PacktPublishing/-Blueprints-Visual-Scripting-for-Unreal-Engine-5 |
+| *Unreal Engine Blueprints Visual Scripting Projects* — Lauren Ferro (Packt) | Project-based; UE4-era, patterns still valid; code: https://github.com/PacktPublishing/Unreal-Engine-Blueprints-Visual-Scripting-Projects |
+
+## Co-op design references (design, not code)
+
+| Reference | Takeaway used in the guide |
+|---|---|
+| Elden Ring **Seamless Co-op** mod (LukeYui) — https://www.nexusmods.com/eldenring/mods/510 | The built-for-co-op model: persistent session, respawn-at-grace on death, spectate during boss, everyone rides on; configurable per-player HP scaling |
+| Elden Ring vanilla scaling (illusorywall's data-mining) | Boss HP ≈ ×1.6 with one phantom, ×2.3 with two — Ch. 11.3's reference numbers |
+| Remnant 2 multiplayer — https://remnant2.wiki.gg/wiki/Multiplayer | Bleed-out/revive design (relic cost, post-revive i-frames patch, damage-drains-bleed-out); 15%/player damage scaling after their balance patch; instanced-to-all loot |
+| Lords of the Fallen 2.0 update | Launch host-favored loot was so disliked they patched to 100%/100% — decide loot generosity early |
+| Nioh 2 Expeditions | Shared team-life-pool alternative to individual bleed-outs |
+
+---
+
+*A note on link rot: URLs verified July 2026. Epic's dev.epicgames.com slugs are stable; YouTube links less so — search the listed title + author if one dies.*

--- a/guides/coop-soulslike-ue5/resources.md
+++ b/guides/coop-soulslike-ue5/resources.md
@@ -32,8 +32,9 @@ Everything referenced across the guide, plus the best of what's out there, organ
 
 | Resource | What it's for |
 |---|---|
-| ⭐ **Ali Elzoheiry (YouTube)** — combo system: https://www.youtube.com/watch?v=Q5xk5PYlQ1k ; Smart Enemy AI playlist: https://www.youtube.com/playlist?list=PLNwKK6OwH7eW1n49TW6-FmiZhqRn97cRy | The best BP series for this genre: combos, damage-info structs, group AI with **attack tokens** (Part 11), EQS strafing (Part 4), boss fights (Parts 20–22). Ch. 6/8/9 follow the same architecture. |
-| **UnrealRPGMastery — Soulslike Combat series** — https://www.youtube.com/watch?v=HWxS-oe0kTo ; full Udemy course: https://www.udemy.com/course/unreal-engine-5-soulslike-combat/ | Soup-to-nuts soulslike melee: stats component, combos, directional dodge, lock-on, hit detection, boss AI |
+| ⭐ **Ali Elzoheiry (YouTube)** — Smart Enemy AI playlist: https://www.youtube.com/playlist?list=PLNwKK6OwH7eW1n49TW6-FmiZhqRn97cRy ; damage system: https://www.youtube.com/watch?v=o3uFXnNxwKE | The best BP series for this genre's combat/AI: damage-info structs, group AI with **attack tokens** (Part 11: https://www.youtube.com/watch?v=tGHjB1Bu8b4), EQS strafing (Part 4), player block/parry/combos (Part 19), boss fights (Parts 20–22: https://www.youtube.com/watch?v=rf-WXW1eI4Q). Ch. 6/8/9 follow the same architecture. |
+| **Unreal University — Attack Combo System** — https://www.youtube.com/watch?v=Q5xk5PYlQ1k | Montage-section combo chain with input buffering — the alternative combo style noted in Ch. 6.1 |
+| **Game Code Mastery (formerly UnrealRPGMastery) — Soulslike Combat series** — https://www.youtube.com/watch?v=HWxS-oe0kTo ; full Udemy course: https://www.udemy.com/course/unreal-engine-5-soulslike-combat/ | Soup-to-nuts soulslike melee: stats component, combos, directional dodge, lock-on, hit detection, boss AI |
 | **Gorka Games — UE5 RPG series #12 (Target Lock & Dodge Roll)** — https://dev.epicgames.com/community/learning/tutorials/JXnb/unreal-engine-5-rpg-tutorial-series-12-target-lock-and-dodge-roll | Free text+video lock-on & roll matching Ch. 4/7 |
 | Epic community — Networked Dash (Root Motion) — https://dev.epicgames.com/community/learning/tutorials/WzoK/unreal-engine-networked-dash-root-motion | The Server→Multicast root-motion montage recipe (our dodge) |
 | Epic community — Dodge Roll with Root Motion — https://dev.epicgames.com/community/learning/tutorials/aVpz/how-to-make-a-dodge-roll-with-root-motion-in-unreal-engine-5 | Root-motion roll setup |
@@ -97,4 +98,4 @@ Everything referenced across the guide, plus the best of what's out there, organ
 
 ---
 
-*A note on link rot: URLs verified July 2026. Epic's dev.epicgames.com slugs are stable; YouTube links less so — search the listed title + author if one dies.*
+*A note on link rot: every URL above was link-checked from an unrestricted network in July 2026 (HTTP 200, and YouTube links verified by title + channel via oEmbed). Four sites block automated checks but confirmed live by other means: fab.com, udemy.com, nexusmods.com (open them in a browser), and remnant2.wiki.gg (page confirmed via its MediaWiki API). If a YouTube link dies later, search the listed title + author.*


### PR DESCRIPTION
## Summary

Adds `guides/coop-soulslike-ue5/` — a 12-chapter, Blueprint-first implementation guide for building a 2–4 player online co-op soulslike in Unreal Engine 5, plus an annotated resources appendix.

- Chapters 1–3: project setup, the server-authoritative replication model, sessions (LAN → Steam/EOS)
- Chapters 4–7: stamina/dodge with i-frames, unified damage pipeline (health/poise/stagger), combo melee with animation-driven weapon traces, lock-on targeting
- Chapters 8–9: Behavior Tree AI with attack tokens and co-op threat tables, a two-phase boss encounter
- Chapters 10–11: bonfires/souls/bloodstains built for co-op (respawn, not level-reload), revive/bleed-out/wipe rules, player-count scaling, party HUD
- Chapter 12: packaging, network perf pass, prioritized C++/GAS migration map

Diagrams are Mermaid (render on GitHub), code examples are structured Blueprint pseudocode with exact node names, each chapter ends with a checklist and a 2-client test matrix.

All 55 external URLs link-checked (HTTP 200 or confirmed live via API/browser); YouTube links verified by title + channel via oEmbed, with two attributions corrected in the follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)