### PR TITLE
ci: keep metrics-renders from drifting off master

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -12,6 +12,19 @@ jobs:
     env:
       METRICS_IMAGE_OVERRIDE: 'ghcr.io/erancihan/lowlighter-github-metrics:devel'
     steps:
+      # Keep metrics-renders from drifting: recreate it as master + a single
+      # fresh "chore: update metrics" commit every run. Resetting the branch to
+      # master here drops all prior metrics commits; the action below then adds
+      # exactly one new commit on top. The README embeds github-metrics.svg from
+      # this branch, so it must continue to exist with that file.
+      - name: Checkout master
+        uses: actions/checkout@v7
+        with:
+          ref: master
+          fetch-depth: 0
+      - name: Reset metrics-renders branch to master
+        run: git push --force origin HEAD:refs/heads/metrics-renders
+
       - uses: erancihan/lowlighter-github-metrics@devel
         with:
           user: erancihan


### PR DESCRIPTION
Resets the metrics-renders branch to master before the metrics action runs, so it is always master + a single fresh `chore: update metrics` commit instead of drifting behind (currently 41 commits behind + stale snapshot).

The action still renders and commits `github-metrics.svg` itself; the README embed from the metrics-renders branch keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)