### PR TITLE
Add go-otp project as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "projects/claude-statusline"]
 	path = projects/claude-statusline
 	url = git@github.com:erancihan/claude-statusline.git
+[submodule "projects/go-otp"]
+	path = projects/go-otp
+	url = git@github.com:erancihan/go-otp.git


### PR DESCRIPTION
## Summary
This PR adds the `go-otp` project as a git submodule to the projects directory.

## Changes
- Added `projects/go-otp` submodule pointing to `git@github.com:erancihan/go-otp.git`
- Updated `.gitmodules` configuration to track the new submodule
- Submodule pinned to commit `49e025597bbedd776b4375a36cc6139570c3f569`

## Details
The go-otp project has been integrated as a submodule, allowing it to be maintained as a separate repository while being included in this monorepo structure.

https://claude.ai/code/session_01PiahgUxR74ENw9c9xcGEar