### PR TITLE
Add negotiation-ecs as a submodule under projects

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "projects/go-otp"]
 	path = projects/go-otp
 	url = git@github.com:erancihan/go-otp.git
+[submodule "projects/negotiation-ecs"]
+	path = projects/negotiation-ecs
+	url = git@github.com:erancihan/negotiation-ecs.git


### PR DESCRIPTION
Graduates the ECS multi-agent negotiation simulator from playground/ to its own repository (github.com/erancihan/negotiation-ecs), referenced here as a submodule like the other projects.


Claude-Session: https://claude.ai/code/session_01Jz6oP3Aywxdng9XYh3zD28