### PR TITLE
Add todo-app (Daybook) as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "projects/negotiation-ecs"]
 	path = projects/negotiation-ecs
 	url = git@github.com:erancihan/negotiation-ecs.git
+[submodule "projects/todo-app"]
+	path = projects/todo-app
+	url = git@github.com:erancihan/todo-app.git


### PR DESCRIPTION
Adds `projects/todo-app` as a submodule pointing at [erancihan/todo-app](https://github.com/erancihan/todo-app), pinned to its initial commit (`5ada00f` — the Daybook planning docs: PRD, architecture, data model, UX, roadmap).

- `.gitmodules` entry follows the existing `git@github.com:` SSH URL convention used by the other submodules.
- After pulling: `git submodule update --init projects/todo-app`.

The Daybook project (docs and, going forward, code) is developed in its own repository; this monorepo only tracks the pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aDmDwRNmDV9dwwbAqVeZN

---
_Generated by [Claude Code](https://claude.ai/code/session_018aDmDwRNmDV9dwwbAqVeZN)_